### PR TITLE
Add demo GIF to README header

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@ Identity. Policy. Approval. Trace.
 
 <a href="https://sidclaw.com" target="_blank">Website</a> · <a href="https://docs.sidclaw.com" target="_blank">Documentation</a> · <a href="https://demo.sidclaw.com" target="_blank">Live Demo</a> · <a href="https://www.npmjs.com/package/@sidclaw/sdk" target="_blank">SDK on npm</a> · <a href="https://pypi.org/project/sidclaw/" target="_blank">SDK on PyPI</a>
 
+<a href="https://demo.sidclaw.com" target="_blank"><img src="apps/landing/public/demos/atlas_demo.gif" alt="SidClaw approval workflow demo — AI agent requests email send, reviewer approves" width="720"></a>
+
 </div>
 
 ---


### PR DESCRIPTION
## Summary
- Adds the financial services approval flow demo GIF (`atlas_demo.gif`) to the README header, below the badges and navigation links
- The GIF links to the live demo at demo.sidclaw.com
- Per devtools best practices: demo GIF at the top of README significantly increases engagement — most devs evaluate tools entirely from the README

## Visual
The GIF shows: AI agent requests email send → approval card appears → reviewer approves → trace complete

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>