### PR TITLE
release: ship the 2026-07-15 governance fail-closed fixes to npm

### DIFF
--- a/packages/openclaw-plugin/package.json
+++ b/packages/openclaw-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sidclaw/openclaw-plugin",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "description": "OpenClaw plugin — SidClaw governance (policy, approvals, audit trail, cost attribution) for OpenClaw agents.",
   "license": "MIT",
   "author": "SidClaw",
@@ -39,7 +39,7 @@
     "plugin"
   ],
   "peerDependencies": {
-    "@sidclaw/sdk": "^0.1.11",
+    "@sidclaw/sdk": "^0.1.12",
     "openclaw": ">=2026.4.0"
   },
   "peerDependenciesMeta": {

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sidclaw/sdk",
-  "version": "0.1.11",
+  "version": "0.1.12",
   "description": "Governance SDK for AI agents — identity, policy, approval, and audit",
   "license": "Apache-2.0",
   "type": "module",

--- a/packages/sdk/src/bin/__tests__/sidclaw-mcp-proxy.test.ts
+++ b/packages/sdk/src/bin/__tests__/sidclaw-mcp-proxy.test.ts
@@ -4,10 +4,18 @@ import { resolve } from 'path';
 
 const CLI_PATH = resolve(__dirname, '../../../dist/bin/sidclaw-mcp-proxy.cjs');
 
+// Strip ambient SIDCLAW_* vars so the "missing variable" cases actually test a
+// missing variable. A developer shell (or .claude/settings.json) that exports
+// SIDCLAW_API_KEY would otherwise leak in and fail the assertions locally while
+// CI stays green.
+const cleanEnv = Object.fromEntries(
+  Object.entries(process.env).filter(([key]) => !key.startsWith('SIDCLAW_'))
+);
+
 function runCLI(env: Record<string, string> = {}) {
   try {
     const output = execFileSync('node', [CLI_PATH], {
-      env: { ...process.env, ...env },
+      env: { ...cleanEnv, ...env },
       timeout: 5000,
       encoding: 'utf-8',
       stdio: ['pipe', 'pipe', 'pipe'],


### PR DESCRIPTION
## Why

The seven hardening fixes merged on 2026-07-15 (#57) **were never released**. No package version was bumped, so npm still serves the pre-fix builds under the same version strings — which is why there was no drift signal.

Verified by unpacking the published tarballs:

| Package | What npm serves today |
|---|---|
| `@sidclaw/sdk@0.1.11` | `resources/read` and `prompts/get` appear in **0** dist files — they bypassed `evaluate` entirely and were proxied straight to upstream, unaudited |
| `@sidclaw/openclaw-plugin@0.3.1` | `dist/index.js:88` still contains `if (READ_ONLY_TOOL_NAMES.has(lower)) return null;` — an allowlist keyed on the **agent-supplied tool name**, so a tool named `fetch` skipped policy evaluation, approval, and the audit trace |

## What's in this PR

Version bumps only — the code fixes are already on `main`.

- `@sidclaw/sdk` 0.1.11 → **0.1.12**
- `@sidclaw/openclaw-plugin` 0.3.1 → **0.3.2** (peer `@sidclaw/sdk` → `^0.1.12`)

Patch-level deliberately, so existing `^0.1.11` / `^0.3.1` consumers actually receive the fix. A minor bump would have left them pinned to the vulnerable build.

⚠️ **This changes runtime behaviour.** Wrappers now throw on any decision that is not an explicit `allow`, and previously-skipped tools now reach `evaluate`. Agents that relied on the fail-open path will start being blocked — which is the point, but it should be called out in the release notes.

Also fixes a fragile test: `sidclaw-mcp-proxy.test.ts` inherited `process.env`, so an ambient `SIDCLAW_API_KEY` leaked in and failed the "missing variable" assertions locally while CI stayed green. It now strips `SIDCLAW_*` from the child environment.

## Verification

- `@sidclaw/sdk` — 242/242 vitest, clean build
- `@sidclaw/openclaw-plugin` — 29/29 vitest, clean build
- Both dists rebuilt and confirmed to contain all four fixes; `READ_ONLY_TOOL_NAMES` confirmed absent

## Not in this PR

- `security.yml:29` carries `continue-on-error: true` on the high-severity audit gate, which is why 8 high advisories pass silently. Removing it turns `main` red until those are patched — needs its own PR.
- All 8 production Dockerfiles pin `node:20-alpine`; Node 20 went EOL 2026-04-30.

🤖 Generated with [Claude Code](https://claude.com/claude-code)