### PR TITLE
fix(release): repair the two defects that have broken every release run

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -78,7 +78,20 @@ jobs:
         run: |
           # Prereleases (e.g. v0.1.11-rc1, sdk-v0.2.0-beta.3) publish to
           # the `next` dist-tag so they do not become the default install.
-          if [[ "${GITHUB_REF_NAME}" == *"-"* ]]; then
+          #
+          # Strip the tag prefix before testing for a prerelease hyphen. The
+          # prefixes themselves contain hyphens (sdk-v, mcp-tools-v, ...), so
+          # testing the whole ref name classified EVERY package-scoped release
+          # as a prerelease — it would publish to `next` and never become the
+          # default install, silently shipping to nobody.
+          TAG="${GITHUB_REF_NAME}"
+          PREFIX="${{ matrix.package.tag_prefix }}"
+          if [[ "$TAG" == v*.*.* ]]; then
+            VERSION="${TAG#v}"
+          else
+            VERSION="${TAG#${PREFIX}}"
+          fi
+          if [[ "$VERSION" == *"-"* ]]; then
             echo "tag=next" >> $GITHUB_OUTPUT
           else
             echo "tag=latest" >> $GITHUB_OUTPUT

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -200,11 +200,12 @@
   ],
   "repository": {
     "type": "git",
-    "url": "https://github.com/sidclawhq/sdk"
+    "url": "https://github.com/sidclawhq/platform",
+    "directory": "packages/sdk"
   },
   "homepage": "https://docs.sidclaw.com",
   "bugs": {
-    "url": "https://github.com/sidclawhq/sdk/issues"
+    "url": "https://github.com/sidclawhq/platform/issues"
   },
   "devDependencies": {
     "@sidclaw/shared": "*",


### PR DESCRIPTION
The `sdk-v0.1.12` run failed at **Publish to npm** with `E422`. The missing `NPM_TOKEN` was real, but it was masking two independent latent bugs — which is why **all 4 prior release runs also failed**.

## 1. `packages/sdk` declared the wrong repository

```
npm error code E422
Error verifying sigstore provenance bundle: Failed to validate repository information:
package.json: "repository.url" is "git+https://github.com/sidclawhq/sdk.git",
expected to match "https://github.com/sidclawhq/platform" from provenance
```

npm validates the sigstore provenance bundle against `package.json`. The SDK pointed at `sidclawhq/sdk`, a repo the code doesn't live in. **Every other package in the matrix already pointed at `sidclawhq/platform`** — which is exactly why only the SDK job failed while cli / mcp-tools / openclaw-plugin / demo passed. `bugs.url` had the same wrong repo and is corrected too.

## 2. Every scoped release was misclassified as a prerelease

```bash
if [[ "${GITHUB_REF_NAME}" == *"-"* ]]; then echo "tag=next"
```

The tag prefixes themselves contain hyphens — `sdk-v`, `mcp-tools-v`, `cli-v`, `openclaw-plugin-v`, `demo-v`. So `sdk-v0.1.12` was read as a prerelease and published to the **`next`** dist-tag.

This one is worth dwelling on: it would not have failed. The artifact would have uploaded, the run would have gone green, and `npm install @sidclaw/sdk` would still have resolved to the vulnerable `0.1.11`. The security fix would have shipped to nobody, silently, and the dashboard would have said success.

Now strips the prefix before testing, reusing the same extraction the `Verify tag matches package.json version` step already does. Only a genuine prerelease version (`0.2.0-rc1`) reaches `next`.

## State

Nothing was published by the failed run — npm is still at `@sidclaw/sdk@0.1.11` and `@sidclaw/openclaw-plugin@0.3.1`. After this merges, the `sdk-v0.1.12` tag gets re-pointed at the new commit and re-pushed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)