### PR TITLE
fix(release): stop marking every scoped release as a GitHub pre-release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -227,9 +227,25 @@ jobs:
       - name: Check out platform (non-python tags)
         if: ${{ !startsWith(github.ref_name, 'python-v') }}
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - name: Determine release channel
+        id: channel
+        run: |
+          # Strip the tag prefix before testing for a prerelease hyphen. Same
+          # bug as the npm dist-tag step had: the prefixes themselves contain
+          # hyphens (sdk-v, mcp-tools-v, openclaw-plugin-v, python-v), so
+          # `contains(github.ref_name, '-')` marked EVERY scoped release as a
+          # pre-release. `##*v` strips up to the last `v`, which handles both
+          # the bare `v0.1.3` and prefixed `sdk-v0.1.12` forms.
+          VERSION="${GITHUB_REF_NAME##*v}"
+          if [[ "$VERSION" == *"-"* ]]; then
+            echo "prerelease=true" >> $GITHUB_OUTPUT
+          else
+            echo "prerelease=false" >> $GITHUB_OUTPUT
+          fi
+
       - name: Create GitHub Release
         uses: softprops/action-gh-release@153bb8e04406b158c6c84fc1615b65b24149a1fe # v2.6.1
         with:
           generate_release_notes: true
           name: ${{ github.ref_name }}
-          prerelease: ${{ contains(github.ref_name, '-') }}
+          prerelease: ${{ steps.channel.outputs.prerelease }}


### PR DESCRIPTION
Third instance of the same hyphen bug, found by checking the result rather than trusting the green run.

`release.yml:235` used `prerelease: ${{ contains(github.ref_name, '-') }}`. The tag prefixes contain hyphens, so `sdk-v0.1.12` and `openclaw-plugin-v0.3.2` — the first two GitHub Releases this project has ever produced — were both published as **pre-releases**.

Not just cosmetic: GitHub excludes pre-releases from the "Latest" badge and from the `releases/latest` API. The homepage Changelog link would have continued to look empty, which is the exact complaint the audit raised about it.

Fixed the same way as the npm dist-tag step: strip the prefix, then test the version. `##*v` handles both the bare `v0.1.3` and prefixed `sdk-v0.1.12` forms.

The two existing releases have already been relabelled via `gh release edit`.

## Release status

Both packages are live and verified:

| Package | Version | dist-tag | Verified |
|---|---|---|---|
| `@sidclaw/sdk` | 0.1.12 | `latest` | `resources/read`, `prompts/get`, `timingSafeEqual` all present in the published tarball; SLSA provenance attached |
| `@sidclaw/openclaw-plugin` | 0.3.2 | `latest` | `READ_ONLY_TOOL_NAMES` absent from the published dist |

🤖 Generated with [Claude Code](https://claude.com/claude-code)