### PR TITLE
fix(sdk): fail closed in withGovernance — 13c6ab3 missed the generic wrapper

### DIFF
--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sidclaw/sdk",
-  "version": "0.1.12",
+  "version": "0.1.13",
   "description": "Governance SDK for AI agents — identity, policy, approval, and audit",
   "license": "Apache-2.0",
   "type": "module",

--- a/packages/sdk/src/middleware/__tests__/governance.test.ts
+++ b/packages/sdk/src/middleware/__tests__/governance.test.ts
@@ -263,3 +263,90 @@ describe('withGovernance()', () => {
     expect(mockFn).toHaveBeenCalledWith('arg1', 42, { key: 'value' });
   });
 });
+
+describe('withGovernance — fail closed', () => {
+  // 13c6ab3 added the explicit-allow guard to langchain.ts but missed this
+  // file, so @sidclaw/sdk shipped withGovernance — the generic wrapper
+  // exported from the package root — on a denylist through v0.1.12. Two
+  // separate fall-throughs existed: the decision branch and the approval
+  // status branch. Both reached the wrapped function.
+  let client: AgentIdentityClient;
+
+  beforeEach(() => {
+    client = createMockClient();
+  });
+
+  it.each(['quarantine', 'log', 'ALLOW', '', undefined, null])(
+    'does not execute the wrapped fn on decision %p',
+    async (decision) => {
+      vi.mocked(client.evaluate).mockResolvedValue({
+        decision,
+        trace_id: 'trace-x',
+        approval_request_id: null,
+        reason: 'unrecognised',
+        policy_rule_id: null,
+      } as unknown as EvaluateResponse);
+
+      const fn = vi.fn().mockResolvedValue('executed');
+      const guarded = withGovernance(client, GOVERNANCE_CONFIG, fn);
+
+      await expect(guarded()).rejects.toThrow(ActionDeniedError);
+      expect(fn).not.toHaveBeenCalled();
+    }
+  );
+
+  it.each(['pending', 'escalated', ''])(
+    'does not execute the wrapped fn when approval status is %p',
+    async (status) => {
+      vi.mocked(client.evaluate).mockResolvedValue({
+        decision: 'approval_required',
+        trace_id: 'trace-y',
+        approval_request_id: 'apr-1',
+        reason: 'needs review',
+        policy_rule_id: null,
+      } as unknown as EvaluateResponse);
+      vi.mocked(client.waitForApproval).mockResolvedValue({
+        id: 'apr-1',
+        status,
+      } as unknown as ApprovalStatusResponse);
+
+      const fn = vi.fn().mockResolvedValue('executed');
+      const guarded = withGovernance(client, GOVERNANCE_CONFIG, fn);
+
+      await expect(guarded()).rejects.toThrow(/Approval not granted/);
+      expect(fn).not.toHaveBeenCalled();
+    }
+  );
+
+  it('still executes on an explicit allow', async () => {
+    vi.mocked(client.evaluate).mockResolvedValue(makeAllowDecision());
+    vi.mocked(client.recordOutcome).mockResolvedValue(undefined as never);
+
+    const fn = vi.fn().mockResolvedValue('executed');
+    const guarded = withGovernance(client, GOVERNANCE_CONFIG, fn);
+
+    await expect(guarded()).resolves.toBe('executed');
+    expect(fn).toHaveBeenCalledOnce();
+  });
+
+  it('still executes after an explicit approval', async () => {
+    vi.mocked(client.evaluate).mockResolvedValue({
+      decision: 'approval_required',
+      trace_id: 'trace-z',
+      approval_request_id: 'apr-2',
+      reason: 'needs review',
+      policy_rule_id: null,
+    } as unknown as EvaluateResponse);
+    vi.mocked(client.waitForApproval).mockResolvedValue({
+      id: 'apr-2',
+      status: 'approved',
+    } as unknown as ApprovalStatusResponse);
+    vi.mocked(client.recordOutcome).mockResolvedValue(undefined as never);
+
+    const fn = vi.fn().mockResolvedValue('executed');
+    const guarded = withGovernance(client, GOVERNANCE_CONFIG, fn);
+
+    await expect(guarded()).resolves.toBe('executed');
+    expect(fn).toHaveBeenCalledOnce();
+  });
+});

--- a/packages/sdk/src/middleware/governance.ts
+++ b/packages/sdk/src/middleware/governance.ts
@@ -76,7 +76,25 @@ export function withGovernance<TArgs extends unknown[], TResult>(
         );
       }
 
-      // approved — fall through to execute
+      // Allowlist: only an explicit approval proceeds. Enumerating the bad
+      // statuses let anything else — a 'pending' return, or a status added
+      // later — fall through and execute the guarded call.
+      if (approval.status !== 'approved') {
+        throw new ActionDeniedError(
+          `Approval not granted: ${String(approval.status)}`,
+          decision.trace_id,
+          decision.policy_rule_id
+        );
+      }
+    } else if (decision.decision !== 'allow') {
+      // Fail closed on any decision that is not an explicit allow. 13c6ab3
+      // fixed this in langchain.ts but missed withGovernance, the generic
+      // wrapper exported from the package root.
+      throw new ActionDeniedError(
+        `Unexpected policy decision: ${String(decision.decision)}`,
+        decision.trace_id,
+        decision.policy_rule_id
+      );
     }
 
     // 4. Execute the wrapped function


### PR DESCRIPTION
## The gap

`13c6ab3` ("fail closed on unknown governance decision in wrappers") added the explicit-allow guard to **`middleware/langchain.ts` only**. `withGovernance` — the generic wrapper exported from the package root, the one the README and docs lead with — kept its denylist and shipped that way in every release **up to and including `@sidclaw/sdk@0.1.12`, published earlier today as the security fix**.

Verified against the published tarball, not the source:

```
$ npm pack @sidclaw/sdk@0.1.12
  dist/index.js:  decision.decision === "deny"  →  unconditional await fn(...args)
  allow-first checks in index.js: 0
```

## Two fall-throughs, not one

1. **Decision branch** — anything not `deny` and not `approval_required` reached `await fn(...args)` and executed ungoverned.
2. **Approval-status branch** — enumerated `denied` and `expired`, so any other status (a `pending` return, or one added later) *also* reached execution. Only an explicit `approved` should proceed.

Exactly mirrors the `generic.py` twin in the Python SDK, fixed in `sidclawhq/python-sdk@54b2899`.

## What is deliberately NOT changed

Audited all six TS middleware files that branch on a decision rather than assuming from the pattern. `claude-agent-sdk.ts`, `composio.ts`, `google-adk.ts` and `nemoclaw.ts` are **already correct** — they open with `if (decision.decision === 'allow') return`, the same allowlist written the other way round. `governance.ts` was the only real gap.

## Provenance

Found by an adversarial sweep for allow-by-default paths across both SDKs, the hooks, the plugin, and the server-side decision contract: **47 candidates, 22 refuted, 7 confirmed**. Two independent adjudicators reached this finding separately.

## Verification

- 9 new tests covering both fall-throughs plus the two happy paths
- Mutation-checked — neutralising the guard fails 9 of them
- 253 tests pass; guards confirmed present in the rebuilt `dist/`
- Bumped to **0.1.13**

🤖 Generated with [Claude Code](https://claude.com/claude-code)