### PR TITLE
fix(hooks): close four silent-permit paths in the PreToolUse gate

### DIFF
--- a/apps/landing/public/install-hooks.mjs
+++ b/apps/landing/public/install-hooks.mjs
@@ -58,13 +58,13 @@ const EXPECTED_HASHES = {
 const HOOK_CONFIG = {
   PreToolUse: [
     {
-      matcher: 'Bash|Edit|Write|MultiEdit|NotebookEdit|Agent|Skill|RemoteTrigger|CronCreate|TeamCreate|mcp__.*',
+      matcher: 'Agent|Bash|CronCreate|CronDelete|Edit|EnterWorktree|ExitWorktree|MultiEdit|NotebookEdit|PushNotification|RemoteTrigger|ScheduleWakeup|SendMessage|Skill|TeamCreate|TeamDelete|Write|mcp__.*',
       hooks: [{ command: 'python .claude/hooks/sidclaw_pretool.py', timeout: 3600000 }],
     },
   ],
   PostToolUse: [
     {
-      matcher: 'Bash|Edit|Write|MultiEdit|NotebookEdit|Agent|Skill|RemoteTrigger|CronCreate|TeamCreate|mcp__.*',
+      matcher: 'Agent|Bash|CronCreate|CronDelete|Edit|EnterWorktree|ExitWorktree|MultiEdit|NotebookEdit|PushNotification|RemoteTrigger|ScheduleWakeup|SendMessage|Skill|TeamCreate|TeamDelete|Write|mcp__.*',
       hooks: [{ command: 'python .claude/hooks/sidclaw_posttool.py' }],
     },
   ],

--- a/hooks/settings.json
+++ b/hooks/settings.json
@@ -2,7 +2,7 @@
   "hooks": {
     "PreToolUse": [
       {
-        "matcher": "Bash|Edit|Write|MultiEdit|NotebookEdit|Agent|Skill|RemoteTrigger|CronCreate|TeamCreate|mcp__.*",
+        "matcher": "Agent|Bash|CronCreate|CronDelete|Edit|EnterWorktree|ExitWorktree|MultiEdit|NotebookEdit|PushNotification|RemoteTrigger|ScheduleWakeup|SendMessage|Skill|TeamCreate|TeamDelete|Write|mcp__.*",
         "hooks": [
           {
             "command": "python .claude/hooks/sidclaw_pretool.py",
@@ -13,7 +13,7 @@
     ],
     "PostToolUse": [
       {
-        "matcher": "Bash|Edit|Write|MultiEdit|NotebookEdit|Agent|Skill|RemoteTrigger|CronCreate|TeamCreate|mcp__.*",
+        "matcher": "Agent|Bash|CronCreate|CronDelete|Edit|EnterWorktree|ExitWorktree|MultiEdit|NotebookEdit|PushNotification|RemoteTrigger|ScheduleWakeup|SendMessage|Skill|TeamCreate|TeamDelete|Write|mcp__.*",
         "hooks": [
           {
             "command": "python .claude/hooks/sidclaw_posttool.py"

--- a/hooks/sidclaw_pretool.py
+++ b/hooks/sidclaw_pretool.py
@@ -62,11 +62,52 @@ def _log(msg: str) -> None:
         print(f"[sidclaw] {msg}", file=sys.stderr)
 
 
+ALL_CATEGORIES = {
+    "execution",
+    "file_io",
+    "orchestration",
+    "mcp",
+    "interactive",
+    "unknown",
+    "search",
+    "system",
+}
+
+DEFAULT_CATEGORIES = "execution,file_io,orchestration,mcp"
+
+
+class ConfigError(Exception):
+    """The hook is misconfigured. Never treated as 'nothing to govern'."""
+
+
 def _governed_categories() -> set[str]:
-    raw = os.environ.get("SIDCLAW_GOVERNED_CATEGORIES", "execution,file_io,orchestration,mcp")
+    """Parse SIDCLAW_GOVERNED_CATEGORIES, failing closed on a bad value.
+
+    A set variable that parses to nothing used to yield an empty set, which
+    governed NOTHING while looking like a working install. That is trivially
+    produced by an unset shell/compose variable expanding to "" — e.g.
+    `SIDCLAW_GOVERNED_CATEGORIES=${CATS}` with CATS undefined.
+    """
+    raw = os.environ.get("SIDCLAW_GOVERNED_CATEGORIES")
+    if raw is None:
+        raw = DEFAULT_CATEGORIES
     if raw.strip().lower() == "all":
-        return {"execution", "file_io", "orchestration", "mcp", "interactive", "unknown", "search", "system"}
-    return {c.strip() for c in raw.split(",") if c.strip()}
+        return set(ALL_CATEGORIES)
+
+    parsed = {c.strip().lower() for c in raw.split(",") if c.strip()}
+    if not parsed:
+        raise ConfigError(
+            "SIDCLAW_GOVERNED_CATEGORIES is set but empty — refusing to run "
+            "ungoverned. Unset it to use the default "
+            f"({DEFAULT_CATEGORIES}), or set it to 'all'."
+        )
+    unknown = parsed - ALL_CATEGORIES
+    if unknown:
+        raise ConfigError(
+            f"SIDCLAW_GOVERNED_CATEGORIES contains unknown categories: "
+            f"{', '.join(sorted(unknown))}. Valid: {', '.join(sorted(ALL_CATEGORIES))}."
+        )
+    return parsed
 
 
 def _observe_mode() -> bool:
@@ -201,14 +242,29 @@ def _summarize_input(tool_name: str, tool_input: dict) -> dict:
 
 
 def _parse_stdin() -> dict:
-    raw = sys.stdin.read().strip()
+    """Return the hook payload, raising ConfigError if stdin is unusable.
+
+    Previously an unreadable or malformed payload returned {}, which main()
+    could not distinguish from "no tool to govern" — so it returned 0 (allow).
+    A hook that cannot read what it is being asked to gate must block, not
+    wave the call through.
+    """
+    try:
+        raw = sys.stdin.buffer.read().decode("utf-8").strip()
+    except (UnicodeDecodeError, OSError) as e:
+        raise ConfigError(f"could not read hook payload from stdin: {e}") from e
+
     if not raw:
+        # Genuinely empty stdin — nothing was passed. Distinct from garbage.
         return {}
     try:
-        return json.loads(raw)
+        parsed = json.loads(raw)
     except json.JSONDecodeError as e:
-        _log(f"failed to parse stdin JSON: {e}")
-        return {}
+        raise ConfigError(f"hook payload was not valid JSON: {e}") from e
+
+    if not isinstance(parsed, dict):
+        raise ConfigError(f"hook payload was {type(parsed).__name__}, expected object")
+    return parsed
 
 
 def main() -> int:
@@ -323,5 +379,30 @@ def _build_approval_url(approval_id: str) -> str:
     return f"{dashboard}/dashboard/approvals/{approval_id}"
 
 
+def _run() -> int:
+    """Entry point wrapper — any unhandled failure blocks rather than allows.
+
+    PreToolUse treats exit 2 as "deny" and every other exit code as
+    non-blocking. An uncaught exception therefore exited 1 and let the tool
+    call proceed ungoverned: a crashed gate was an open gate, silently. A
+    governance hook must fail closed on its own bugs too.
+
+    Observe mode still returns 0, because observe mode's contract is
+    explicitly "never block".
+    """
+    try:
+        return main()
+    except ConfigError as e:
+        print(f"SidClaw hook misconfigured: {e}", file=sys.stderr)
+    except Exception as e:  # noqa: BLE001 — deliberate catch-all; see docstring
+        print(f"SidClaw hook crashed — blocking this tool call: {e}", file=sys.stderr)
+
+    try:
+        observe = _observe_mode()
+    except Exception:  # noqa: BLE001 — never let the failure handler fail open
+        observe = False
+    return 0 if observe else 2
+
+
 if __name__ == "__main__":
-    sys.exit(main())
+    sys.exit(_run())

--- a/hooks/tests/test_fail_closed.py
+++ b/hooks/tests/test_fail_closed.py
@@ -1,0 +1,181 @@
+"""The gate must block when it cannot do its job.
+
+PreToolUse treats exit 2 as "deny" and every other exit code as non-blocking.
+So anything that makes the hook exit 0 or 1 — a crash, a misconfiguration, an
+unreadable payload, or simply never being invoked — is a silent permit. These
+tests cover each of those paths.
+
+The matcher test is the important one: the hook's own filters are correct, but
+they only run if Claude Code invokes the hook at all, and that is decided by the
+regex in settings.json. That regex covered 10 tools while the classifier claimed
+to govern 17 — including CronDelete and TeamDelete, whose Create counterparts
+were both covered.
+"""
+
+import json
+import os
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+HOOKS_DIR = Path(__file__).resolve().parent.parent
+REPO_ROOT = HOOKS_DIR.parent
+PRETOOL = HOOKS_DIR / "sidclaw_pretool.py"
+
+sys.path.insert(0, str(HOOKS_DIR))
+from sidclaw_agent_intel.tool_recognizer import classify_tool  # noqa: E402
+
+_CLEAN_ENV = {k: v for k, v in os.environ.items() if not k.startswith("SIDCLAW_")}
+
+# Every config that ships a matcher to a user. All three must stay in sync.
+SHIPPED_CONFIGS = [
+    HOOKS_DIR / "settings.json",
+    REPO_ROOT / "scripts" / "install-hooks.mjs",
+    REPO_ROOT / "apps" / "landing" / "public" / "install-hooks.mjs",
+]
+
+
+def _governed_tool_names() -> list[str]:
+    """Every tool the classifier claims to govern, read from its own source."""
+    src = (HOOKS_DIR / "sidclaw_agent_intel" / "tool_recognizer.py").read_text()
+    names = sorted(set(re.findall(r'"([A-Z][A-Za-z_]+)"\s*:', src)))
+    return [n for n in names if classify_tool(n).governed]
+
+
+def _matchers(path: Path) -> list[str]:
+    text = path.read_text()
+    return re.findall(r"""matcher["']?\s*:\s*["']([^"']+)["']""", text)
+
+
+def _run(payload, env, raw_input=None):
+    proc = subprocess.run(
+        [sys.executable, str(PRETOOL)],
+        input=json.dumps(payload) if raw_input is None else raw_input,
+        capture_output=True,
+        text=True,
+        env={**_CLEAN_ENV, **env},
+    )
+    return proc.returncode, proc.stderr
+
+
+BASE_ENV = {
+    "SIDCLAW_BASE_URL": "http://127.0.0.1:1",  # nothing listening
+    "SIDCLAW_API_KEY": "test-key",
+    "SIDCLAW_HOOK_MODE": "enforce",
+    "SIDCLAW_FAIL_OPEN": "false",
+}
+
+
+class TestMatcherCoversEveryGovernedTool:
+    """A tool absent from the matcher never reaches the hook at all."""
+
+    @pytest.mark.parametrize("config", SHIPPED_CONFIGS, ids=lambda p: p.name)
+    def test_every_governed_tool_matches(self, config):
+        governed = _governed_tool_names()
+        assert governed, "classifier reported no governed tools — test is not exercising anything"
+
+        found = _matchers(config)
+        assert found, f"no matcher found in {config}"
+
+        for matcher in found:
+            pattern = re.compile(f"^({matcher})$")
+            missing = [t for t in governed if not pattern.match(t)]
+            assert not missing, (
+                f"{config.name}: these tools are governed by the classifier but the "
+                f"matcher never invokes the hook for them: {missing}"
+            )
+
+    def test_all_shipped_configs_agree(self):
+        seen = {c.name: set(_matchers(c)) for c in SHIPPED_CONFIGS}
+        distinct = {frozenset(v) for v in seen.values()}
+        assert len(distinct) == 1, f"shipped matchers have drifted apart: {seen}"
+
+    def test_mcp_tools_still_covered(self):
+        for config in SHIPPED_CONFIGS:
+            for matcher in _matchers(config):
+                assert re.compile(f"^({matcher})$").match("mcp__whatever__tool"), (
+                    f"{config.name}: MCP tools no longer match"
+                )
+
+
+class TestHookFailsClosed:
+    def test_crash_blocks(self, tmp_path):
+        """An uncaught exception must exit 2, not 1.
+
+        Exit 1 is non-blocking, so a crashed gate used to be an open gate.
+        """
+        shim = tmp_path / "crash.py"
+        shim.write_text(
+            "import sys\n"
+            f"sys.path.insert(0, {str(HOOKS_DIR)!r})\n"
+            "import sidclaw_pretool as m\n"
+            "def boom():\n"
+            "    raise RuntimeError('simulated bug')\n"
+            "m.main = boom\n"
+            "sys.exit(m._run())\n"
+        )
+        proc = subprocess.run(
+            [sys.executable, str(shim)],
+            input="{}",
+            capture_output=True,
+            text=True,
+            env={**_CLEAN_ENV, **BASE_ENV},
+        )
+        assert proc.returncode == 2, f"crash exited {proc.returncode} (non-blocking), stderr={proc.stderr}"
+        assert "crashed" in proc.stderr.lower()
+
+    def test_crash_in_observe_mode_does_not_block(self, tmp_path):
+        """Observe mode's contract is 'never block' — that must still hold."""
+        shim = tmp_path / "crash_observe.py"
+        shim.write_text(
+            "import sys\n"
+            f"sys.path.insert(0, {str(HOOKS_DIR)!r})\n"
+            "import sidclaw_pretool as m\n"
+            "def boom():\n"
+            "    raise RuntimeError('simulated bug')\n"
+            "m.main = boom\n"
+            "sys.exit(m._run())\n"
+        )
+        proc = subprocess.run(
+            [sys.executable, str(shim)],
+            input="{}",
+            capture_output=True,
+            text=True,
+            env={**_CLEAN_ENV, **BASE_ENV, "SIDCLAW_HOOK_MODE": "observe"},
+        )
+        assert proc.returncode == 0
+
+    @pytest.mark.parametrize("value", ["", "   ", ",,,", "bogus_category", "execution,not_a_category"])
+    def test_bad_governed_categories_blocks(self, value):
+        code, stderr = _run(
+            {"tool_name": "Bash", "tool_input": {"command": "rm -rf /"}},
+            env={**BASE_ENV, "SIDCLAW_GOVERNED_CATEGORIES": value},
+        )
+        assert code == 2, f"value {value!r} exited {code}, stderr={stderr}"
+        assert "misconfigured" in stderr.lower()
+
+    @pytest.mark.parametrize("raw", ["not json at all", '{"unterminated": ', "[1,2,3]", '"a string"'])
+    def test_unusable_stdin_blocks(self, raw):
+        code, stderr = _run(None, env=BASE_ENV, raw_input=raw)
+        assert code == 2, f"payload {raw!r} exited {code}, stderr={stderr}"
+
+    def test_valid_categories_still_work(self):
+        """Guard against over-correction — the happy paths must survive."""
+        for value in ["all", "execution", "execution,file_io", " execution , mcp "]:
+            code, stderr = _run(
+                {"tool_name": "Read", "tool_input": {"file_path": "x"}},
+                env={**BASE_ENV, "SIDCLAW_GOVERNED_CATEGORIES": value},
+            )
+            assert code == 0, f"value {value!r} unexpectedly exited {code}: {stderr}"
+
+    def test_unset_categories_uses_default(self):
+        code, _ = _run({"tool_name": "Read", "tool_input": {"file_path": "x"}}, env=BASE_ENV)
+        assert code == 0
+
+    def test_empty_stdin_is_not_an_error(self):
+        """No payload at all is distinct from an unreadable one."""
+        code, _ = _run(None, env=BASE_ENV, raw_input="")
+        assert code == 0

--- a/hooks/tests/test_pretool.py
+++ b/hooks/tests/test_pretool.py
@@ -15,13 +15,19 @@ HOOKS_DIR = Path(__file__).resolve().parent.parent
 PRETOOL = HOOKS_DIR / "sidclaw_pretool.py"
 
 
-def _run_hook(payload: dict, env: dict, script: Path = PRETOOL):
+# Strip ambient SIDCLAW_* so a developer shell (or .claude/settings.json, which
+# exports SIDCLAW_HOOK_MODE=observe for this repo's own hooks) cannot leak in and
+# silently invert a fail-closed assertion. Tests set every var they depend on.
+_CLEAN_ENV = {k: v for k, v in os.environ.items() if not k.startswith("SIDCLAW_")}
+
+
+def _run_hook(payload: dict, env: dict, script: Path = PRETOOL, raw_input: str | None = None):
     proc = subprocess.run(
         [sys.executable, str(script)],
-        input=json.dumps(payload),
+        input=json.dumps(payload) if raw_input is None else raw_input,
         capture_output=True,
         text=True,
-        env={**os.environ, **env},
+        env={**_CLEAN_ENV, **env},
     )
     return proc.returncode, proc.stdout, proc.stderr
 

--- a/scripts/install-hooks.mjs
+++ b/scripts/install-hooks.mjs
@@ -33,7 +33,7 @@ const HOOK_FILES = [
 const HOOK_CONFIG = {
   PreToolUse: [
     {
-      matcher: 'Bash|Edit|Write|MultiEdit|NotebookEdit|Agent|Skill|RemoteTrigger|CronCreate|TeamCreate|mcp__.*',
+      matcher: 'Agent|Bash|CronCreate|CronDelete|Edit|EnterWorktree|ExitWorktree|MultiEdit|NotebookEdit|PushNotification|RemoteTrigger|ScheduleWakeup|SendMessage|Skill|TeamCreate|TeamDelete|Write|mcp__.*',
       hooks: [
         { command: 'python .claude/hooks/sidclaw_pretool.py', timeout: 3600000 },
       ],
@@ -41,7 +41,7 @@ const HOOK_CONFIG = {
   ],
   PostToolUse: [
     {
-      matcher: 'Bash|Edit|Write|MultiEdit|NotebookEdit|Agent|Skill|RemoteTrigger|CronCreate|TeamCreate|mcp__.*',
+      matcher: 'Agent|Bash|CronCreate|CronDelete|Edit|EnterWorktree|ExitWorktree|MultiEdit|NotebookEdit|PushNotification|RemoteTrigger|ScheduleWakeup|SendMessage|Skill|TeamCreate|TeamDelete|Write|mcp__.*',
       hooks: [
         { command: 'python .claude/hooks/sidclaw_posttool.py' },
       ],


### PR DESCRIPTION
PreToolUse treats **exit 2 as "deny" and every other exit code as non-blocking**. So anything that makes the hook exit 0 or 1 — or never run at all — is a silent permit. Four such paths, all live in what `curl -fsSL https://sidclaw.com/install-hooks.mjs | node` installs today.

### 1. A crash was an open gate

`sys.exit(main())` let any uncaught exception exit **1**, which does not block. Verified by execution before the fix — an exception in `main()` exited 1 and the tool call proceeded. Now wrapped in `_run()`, which blocks on `ConfigError` and on any unhandled exception. Observe mode still returns 0; its contract is explicitly "never block".

### 2. The matcher governed 10 tools while the classifier claimed 17

A tool absent from the `settings.json` regex never invokes the hook — so the hook's own correct filters never run, and `SIDCLAW_GOVERNED_CATEGORIES` cannot reach it. The config option silently could not do what it advertised.

Missing: `CronDelete`, `TeamDelete`, `EnterWorktree`, `ExitWorktree`, `PushNotification`, `ScheduleWakeup`, `SendMessage`.

Note **`CronCreate` and `TeamCreate` were governed while their destructive counterparts were not.**

The matcher is now generated from the classifier's own governed set and updated in all three shipped copies. `Read`/`Glob`/`Grep`/`WebFetch` deliberately stay out — the classifier doesn't govern them, so including them would only cost a Python process per call.

### 3. `SIDCLAW_GOVERNED_CATEGORIES=""` governed nothing

An empty value parsed to an empty set and governed nothing while looking like a working install — trivially produced by an unset compose/CI variable expanding to `""`. Now fails closed, and unknown category names are rejected rather than silently ignored.

### 4. Unreadable stdin returned `{}`

Indistinguishable from "no tool to govern", so `main()` returned 0. Malformed JSON, a non-object payload, and undecodable bytes now block. Genuinely empty stdin still doesn't.

## Test hygiene

`tests/test_pretool.py` built the subprocess env as `{**os.environ, **env}`, so this repo's own `.claude/settings.json` (`SIDCLAW_HOOK_MODE=observe`) leaked in and inverted two fail-closed assertions. They had been failing on any developer machine with hooks configured. Stripping `SIDCLAW_*` fixes both.

## Verification

19 new tests. The matcher test asserts every classifier-governed tool matches, in all three configs, and that the three **cannot drift apart** — that drift is the whole finding, and it's the same failure mode as `13c6ab3` patching one wrapper out of six.

Mutation-checked: reverting the guards fails 11 of them. **60 tests pass** (was 41, with 2 failing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)