### PR TITLE
ci: actually run the SDK and hooks test suites

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,6 +45,12 @@ jobs:
           node-version: '20'
           cache: 'npm'
       - run: npm ci
+      # The mcp-proxy CLI suite spawns dist/bin/sidclaw-mcp-proxy.cjs, but
+      # turbo's `test` task declares dependsOn ["^build"] — that is upstream
+      # dependencies only, not the package's own build. Without this step the
+      # CLI tests fail on a fresh checkout while passing on any machine that
+      # happens to have a stale dist/ lying around.
+      - run: npx turbo build --filter=@sidclaw/sdk
       - run: npx turbo test --filter=@sidclaw/sdk
 
   # The Claude Code hooks are the governance gate for zero-code installs and

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,6 +33,33 @@ jobs:
       - run: npm ci
       - run: npx turbo test --filter=@sidclaw/shared
 
+  # The SDK is the published artifact and was previously only BUILT in CI,
+  # never tested — its suite (incl. the fail-closed governance guards) had no
+  # automated enforcement, so a revert would have kept CI green.
+  test-sdk:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        with:
+          node-version: '20'
+          cache: 'npm'
+      - run: npm ci
+      - run: npx turbo test --filter=@sidclaw/sdk
+
+  # The Claude Code hooks are the governance gate for zero-code installs and
+  # ship via curl | node. There was no Python job in CI at all.
+  test-hooks:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
+        with:
+          python-version: '3.11'
+      - run: pip install pytest
+      - run: python -m pytest tests/ -q
+        working-directory: hooks
+
   test-api:
     runs-on: ubuntu-latest
     services:


### PR DESCRIPTION
CI ran `turbo test` for exactly two filters — `@sidclaw/shared` and `@sidclaw/api`. The SDK appeared **only** in `turbo build`, so its 253 tests never executed in CI. There was no Python job at all.

```
$ grep -n "turbo test" .github/workflows/ci.yml
34:      - run: npx turbo test --filter=@sidclaw/shared
71:        run: npx turbo test --filter=@sidclaw/api

$ grep -n "@sidclaw/sdk" .github/workflows/ci.yml
66:        run: npx turbo build --filter=@sidclaw/shared --filter=@sidclaw/sdk
102:        run: npx turbo build --filter=@sidclaw/sdk        ← build only
```

## Why it matters

The fail-closed guards shipped today — `withGovernance` in `@sidclaw/sdk@0.1.13` (#61) and the four PreToolUse paths (#62) — could **both be reverted with CI staying green**. The two most security-relevant surfaces in the repo had zero automated enforcement, which is worse than having no tests: the green check implied otherwise.

## Added

| Job | Runs | Tests |
|---|---|---|
| `test-sdk` | `npx turbo test --filter=@sidclaw/sdk` | 253 |
| `test-hooks` | `pytest` in `hooks/` | 60 |

`hooks` needs only `pytest` — everything else it imports is stdlib, verified by scanning every import across `hooks/**/*.py`. `setup-python` is pinned to the commit `v5.6.0` resolves to, checked against the `actions/setup-python` ref API rather than copied from memory.

## Deliberately not in scope

Still uncovered: `mcp-tools`, `cli`, `openclaw-plugin`, `sidclaw-demo`, `integrations/langchain-js`, and `python-sdk` (which has its own CI — green as of today, for the first time). Each needs its own dependency setup, and this change should stay independently reviewable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)