### PR TITLE
fix(compliance): correct the EU AI Act high-risk dates — deferred to Dec 2027

### DIFF
--- a/README.md
+++ b/README.md
@@ -337,7 +337,7 @@ AI agents are being deployed in production, but the governance layer is missing:
 - **73% of CISOs** fear AI agent risks, but only **30%** are ready (<a href="https://neuraltrust.ai/guides/the-state-of-ai-agent-security-2026" target="_blank">NeuralTrust 2026</a>)
 - **79% of enterprises** have blind spots where agents act without oversight
 - **FINRA 2026** explicitly requires "documented human checkpoints" for AI agent actions in financial services
-- **EU AI Act** (August 2026) mandates human oversight, automatic logging, and risk management for high-risk AI systems
+- **EU AI Act** mandates human oversight, automatic logging, and risk management for high-risk AI systems — obligations apply from **2 December 2027** (Annex III) and **2 August 2028** (product-embedded), deferred from August 2026 by the 2026 Digital Omnibus
 - **OpenClaw** has 329K+ stars and 13,700+ skills — but <a href="https://thehackernews.com/2026/02/researchers-find-341-malicious-clawhub.html" target="_blank">1,184 malicious skills were found</a> in the ClawHavoc campaign. There's no policy layer governing what skills can do.
 
 The big vendors (Okta, SailPoint, WorkOS) handle identity and authorization. But none of them ship the **approval step** — the part where a human sees rich context and makes an informed decision before an agent acts.

--- a/apps/docs/content/docs/compliance/eu-ai-act.mdx
+++ b/apps/docs/content/docs/compliance/eu-ai-act.mdx
@@ -5,9 +5,11 @@ description: How SidClaw maps to EU AI Act requirements for high-risk AI systems
 
 # EU AI Act Compliance Mapping
 
-The EU AI Act (Regulation 2024/1689) establishes comprehensive requirements for AI systems operating in the European Union. High-risk AI system provisions take effect on **August 2, 2026**. Penalties for non-compliance reach up to **35 million EUR or 7% of global annual turnover**, whichever is higher.
+The EU AI Act (Regulation 2024/1689) establishes comprehensive requirements for AI systems operating in the European Union. Penalties for non-compliance reach up to **35 million EUR or 7% of global annual turnover**, whichever is higher.
 
 This page maps the articles most relevant to AI agent governance to specific SidClaw capabilities.
+
+> **When the high-risk obligations apply.** The 2026 Digital Omnibus on AI deferred them from the original 2 August 2026 date. Stand-alone high-risk systems (Annex III — financial services, employment, critical infrastructure, law enforcement) now apply from **2 December 2027**; high-risk systems embedded in regulated products (Annex I) from **2 August 2028**. Obligations already in force are unaffected, including the prohibited-practices rules and the Article 4 AI-literacy duty. See the [European Commission's regulatory framework page](https://digital-strategy.ec.europa.eu/en/policies/regulatory-framework-ai) for current dates.
 
 ## Applicability
 

--- a/docs/compliance/eu-ai-act.json
+++ b/docs/compliance/eu-ai-act.json
@@ -1,6 +1,6 @@
 {
   "framework": "EU AI Act",
-  "version": "Regulation (EU) 2024/1689 — high-risk provisions in force 2 August 2026",
+  "version": "Regulation (EU) 2024/1689, as amended by the Digital Omnibus on AI (2026) — stand-alone high-risk provisions (Annex III) apply from 2 December 2027; product-embedded high-risk systems (Annex I) from 2 August 2028",
   "authority": "European Commission",
   "description": "The EU AI Act establishes obligations for providers and deployers of high-risk AI systems (Annex III: financial services, employment, critical infrastructure, law enforcement, and more). SidClaw's four primitives (Identity, Policy, Approval, Trace) provide the technical infrastructure to demonstrate compliance with Articles 9, 10, 12, 13, 14, 15, 17, and 22. Penalties reach up to EUR 35M or 7% of global annual turnover for the most serious breaches.",
   "mapping": [


### PR DESCRIPTION
The shipped compliance bundle, the docs page, and the README all asserted high-risk obligations take effect **2 August 2026**. True when written; now wrong.

The **Digital Omnibus on AI** deferred them:

| Scope | Was | Now |
|---|---|---|
| Stand-alone high-risk (Annex III) | 2 Aug 2026 | **2 Dec 2027** |
| Product-embedded high-risk (Annex I) | 2 Aug 2026 | **2 Aug 2028** |

Annex III is exactly SidClaw's stated verticals — financial services, employment, critical infrastructure, law enforcement. European Parliament gave final approval 16 June 2026. Verified against the [Commission's own page](https://digital-strategy.ec.europa.eu/en/policies/regulatory-framework-ai), which now reads "will apply from 2 December 2027".

## Why this isn't just a stale date

1. `docs/compliance/eu-ai-act.json` is **served to customers** via the dashboard's `/api/compliance/[key]` route as evidence material. A compliance product citing a superseded legal deadline undermines the thing it sells.
2. The original date is **five days away**, so the discrepancy was about to become conspicuous.

Obligations already in force are now called out explicitly — prohibited practices, and the Article 4 AI-literacy duty — so the correction doesn't read as "nothing applies yet".

## Verification

- All 8 article mappings intact; JSON parses
- Used a markdown blockquote rather than `<Callout>`, which is **not registered** in this docs app and would have broken the build
- `next build` green

🤖 Generated with [Claude Code](https://claude.com/claude-code)