### PR TITLE
chore: move off Node 20 (EOL 2026-04-30) to Node 24 Active LTS

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
-          node-version: '20'
+          node-version: '24'
           cache: 'npm'
       - run: npm ci
       - name: Generate Prisma client
@@ -28,7 +28,7 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
-          node-version: '20'
+          node-version: '24'
           cache: 'npm'
       - run: npm ci
       - run: npx turbo test --filter=@sidclaw/shared
@@ -42,7 +42,7 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
-          node-version: '20'
+          node-version: '24'
           cache: 'npm'
       - run: npm ci
       # The mcp-proxy CLI suite spawns dist/bin/sidclaw-mcp-proxy.cjs, but
@@ -89,7 +89,7 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
-          node-version: '20'
+          node-version: '24'
           cache: 'npm'
       - run: npm ci
       - name: Generate Prisma client
@@ -110,7 +110,7 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
-          node-version: '20'
+          node-version: '24'
           cache: 'npm'
       - run: npm ci
       - name: Generate Prisma client
@@ -128,7 +128,7 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
-          node-version: '20'
+          node-version: '24'
           cache: 'npm'
       - run: npm ci
       - name: Build SDK

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -100,7 +100,7 @@ jobs:
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         if: steps.gate.outputs.release == 'true'
         with:
-          node-version: '20'
+          node-version: '24'
           cache: 'npm'
           registry-url: 'https://registry.npmjs.org'
 

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -21,7 +21,7 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
-          node-version: "20"
+          node-version: "24"
           cache: "npm"
       - run: npm ci
       - name: Audit production dependencies

--- a/Dockerfile
+++ b/Dockerfile
@@ -34,7 +34,7 @@
 #   SIDCLAW_PORT                 HTTP port when transport=http (default: 8080)
 #   SIDCLAW_INTROSPECT           "true" to start in introspect mode
 
-FROM node:22-slim
+FROM node:24-slim
 
 WORKDIR /app
 

--- a/apps/api/Dockerfile
+++ b/apps/api/Dockerfile
@@ -1,5 +1,5 @@
 # ── Stage 1: Install dependencies ──────────────────────────────────────────────
-FROM node:20-alpine AS deps
+FROM node:24-alpine AS deps
 WORKDIR /app
 
 COPY package.json package-lock.json ./
@@ -9,7 +9,7 @@ COPY apps/api/package.json ./apps/api/
 RUN npm ci --workspace=apps/api --workspace=packages/shared --ignore-scripts
 
 # ── Stage 2: Build ─────────────────────────────────────────────────────────────
-FROM node:20-alpine AS build
+FROM node:24-alpine AS build
 WORKDIR /app
 
 COPY --from=deps /app/node_modules ./node_modules
@@ -55,7 +55,7 @@ RUN cd packages/shared && rm -rf dist && \
     fs.writeFileSync('package.json', JSON.stringify(pkg, null, 2));"
 
 # ── Stage 3: Production ───────────────────────────────────────────────────────
-FROM node:20-alpine AS production
+FROM node:24-alpine AS production
 WORKDIR /app
 
 RUN addgroup --system --gid 1001 nodejs && \

--- a/apps/dashboard/Dockerfile
+++ b/apps/dashboard/Dockerfile
@@ -1,5 +1,5 @@
 # ── Stage 1: Install dependencies ──────────────────────────────────────────────
-FROM node:20-alpine AS deps
+FROM node:24-alpine AS deps
 WORKDIR /app
 
 COPY package.json package-lock.json ./
@@ -9,7 +9,7 @@ COPY apps/dashboard/package.json ./apps/dashboard/
 RUN npm ci --workspace=apps/dashboard --workspace=packages/shared --ignore-scripts
 
 # ── Stage 2: Build ─────────────────────────────────────────────────────────────
-FROM node:20-alpine AS build
+FROM node:24-alpine AS build
 WORKDIR /app
 
 ARG NEXT_PUBLIC_API_URL=https://api.sidclaw.com
@@ -30,7 +30,7 @@ RUN cd packages/shared && npx tsc --build
 RUN cd apps/dashboard && npm run build
 
 # ── Stage 3: Production ───────────────────────────────────────────────────────
-FROM node:20-alpine AS production
+FROM node:24-alpine AS production
 WORKDIR /app
 
 RUN addgroup --system --gid 1001 nodejs && \

--- a/apps/demo-devops/Dockerfile
+++ b/apps/demo-devops/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:20-alpine AS deps
+FROM node:24-alpine AS deps
 WORKDIR /app
 RUN apk add --no-cache git
 COPY package.json package-lock.json turbo.json ./
@@ -7,7 +7,7 @@ COPY packages/sdk/package.json ./packages/sdk/
 COPY apps/demo-devops/package.json ./apps/demo-devops/
 RUN git init && npm ci --include=dev && rm -rf .git
 
-FROM node:20-alpine AS build
+FROM node:24-alpine AS build
 WORKDIR /app
 COPY --from=deps /app/node_modules ./node_modules
 COPY --from=deps /app/packages/sdk/node_modules ./packages/sdk/node_modules
@@ -19,7 +19,7 @@ RUN npm run build -w packages/shared
 RUN npm run build -w packages/sdk
 RUN npm run build -w apps/demo-devops
 
-FROM node:20-alpine AS production
+FROM node:24-alpine AS production
 WORKDIR /app
 RUN addgroup --system --gid 1001 nodejs && \
     adduser --system --uid 1001 nextjs

--- a/apps/demo-healthcare/Dockerfile
+++ b/apps/demo-healthcare/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:20-alpine AS deps
+FROM node:24-alpine AS deps
 WORKDIR /app
 RUN apk add --no-cache git
 COPY package.json package-lock.json turbo.json ./
@@ -7,7 +7,7 @@ COPY packages/sdk/package.json ./packages/sdk/
 COPY apps/demo-healthcare/package.json ./apps/demo-healthcare/
 RUN git init && npm ci --include=dev && rm -rf .git
 
-FROM node:20-alpine AS build
+FROM node:24-alpine AS build
 WORKDIR /app
 COPY --from=deps /app/node_modules ./node_modules
 COPY --from=deps /app/packages/sdk/node_modules ./packages/sdk/node_modules
@@ -19,7 +19,7 @@ RUN npm run build -w packages/shared
 RUN npm run build -w packages/sdk
 RUN npm run build -w apps/demo-healthcare
 
-FROM node:20-alpine AS production
+FROM node:24-alpine AS production
 WORKDIR /app
 RUN addgroup --system --gid 1001 nodejs && \
     adduser --system --uid 1001 nextjs

--- a/apps/demo/Dockerfile
+++ b/apps/demo/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:20-alpine AS deps
+FROM node:24-alpine AS deps
 WORKDIR /app
 RUN apk add --no-cache git
 COPY package.json package-lock.json turbo.json ./
@@ -7,7 +7,7 @@ COPY packages/sdk/package.json ./packages/sdk/
 COPY apps/demo/package.json ./apps/demo/
 RUN git init && npm ci --include=dev && rm -rf .git
 
-FROM node:20-alpine AS build
+FROM node:24-alpine AS build
 WORKDIR /app
 COPY --from=deps /app/node_modules ./node_modules
 COPY --from=deps /app/packages/sdk/node_modules ./packages/sdk/node_modules
@@ -20,7 +20,7 @@ RUN npm run build -w packages/shared
 RUN npm run build -w packages/sdk
 RUN npm run build -w apps/demo
 
-FROM node:20-alpine AS production
+FROM node:24-alpine AS production
 WORKDIR /app
 RUN addgroup --system --gid 1001 nodejs && \
     adduser --system --uid 1001 nextjs

--- a/apps/docs/Dockerfile
+++ b/apps/docs/Dockerfile
@@ -1,5 +1,5 @@
 # ── Stage 1: Install dependencies ──────────────────────────────────────────────
-FROM node:20-alpine AS deps
+FROM node:24-alpine AS deps
 WORKDIR /app
 
 COPY package.json package-lock.json ./
@@ -8,7 +8,7 @@ COPY apps/docs/package.json ./apps/docs/
 RUN npm ci --workspace=apps/docs --ignore-scripts
 
 # ── Stage 2: Build ─────────────────────────────────────────────────────────────
-FROM node:20-alpine AS build
+FROM node:24-alpine AS build
 WORKDIR /app
 
 COPY --from=deps /app/node_modules ./node_modules
@@ -20,7 +20,7 @@ COPY tsconfig.base.json ./
 RUN cd apps/docs && npm run build
 
 # ── Stage 3: Production ───────────────────────────────────────────────────────
-FROM node:20-alpine AS production
+FROM node:24-alpine AS production
 WORKDIR /app
 
 RUN addgroup --system --gid 1001 nodejs && \

--- a/apps/docs/content/docs/integrations/copilot-studio.mdx
+++ b/apps/docs/content/docs/integrations/copilot-studio.mdx
@@ -34,7 +34,7 @@ The proxy must be accessible over HTTPS. Deploy it to any cloud provider:
 Save this as `Dockerfile`:
 
 ```dockerfile
-FROM node:20-alpine
+FROM node:24-alpine
 WORKDIR /app
 RUN npm init -y && npm install @sidclaw/sdk @modelcontextprotocol/sdk
 EXPOSE 8080

--- a/apps/landing/Dockerfile
+++ b/apps/landing/Dockerfile
@@ -1,5 +1,5 @@
 # ── Stage 1: Install dependencies ──────────────────────────────────────────────
-FROM node:20-alpine AS deps
+FROM node:24-alpine AS deps
 WORKDIR /app
 
 COPY package.json package-lock.json ./
@@ -8,7 +8,7 @@ COPY apps/landing/package.json ./apps/landing/
 RUN npm ci --workspace=apps/landing --ignore-scripts
 
 # ── Stage 2: Build ─────────────────────────────────────────────────────────────
-FROM node:20-alpine AS build
+FROM node:24-alpine AS build
 WORKDIR /app
 
 COPY --from=deps /app/node_modules ./node_modules
@@ -25,7 +25,7 @@ ENV NEXT_PUBLIC_CF_BEACON_TOKEN=$NEXT_PUBLIC_CF_BEACON_TOKEN
 RUN cd apps/landing && npm run build
 
 # ── Stage 3: Production ───────────────────────────────────────────────────────
-FROM node:20-alpine AS production
+FROM node:24-alpine AS production
 WORKDIR /app
 
 RUN addgroup --system --gid 1001 nodejs && \

--- a/examples/docker-compose/docker-compose.yml
+++ b/examples/docker-compose/docker-compose.yml
@@ -38,7 +38,7 @@ services:
       - "3000:3000"
 
   agent:
-    image: node:20-alpine
+    image: node:24-alpine
     depends_on:
       - api
     working_dir: /app

--- a/packages/sdk/Dockerfile.mcp-proxy
+++ b/packages/sdk/Dockerfile.mcp-proxy
@@ -17,7 +17,7 @@
 #   Server URL: https://your-domain.com/mcp
 #   Auth: API Key → Header: Authorization → Value: Bearer ai_your_key
 
-FROM node:20-alpine
+FROM node:24-alpine
 
 WORKDIR /app
 


### PR DESCRIPTION
Node 20 (Iron) reached **End-of-Life on 2026-04-30**. For the last three months the interpreter executing all production code has received no security patches, and the Docker official-images project no longer rebuilds `node:20-alpine` — the tag is frozen at whatever Alpine/OpenSSL/V8 state it had at EOL.

## Node 24, not 22

I assumed 22. That was wrong. Verified against `nodejs/Release` `schedule.json` rather than memory:

| | maintenance | end |
|---|---|---|
| v20 | 2024-10-22 | **2026-04-30** — EOL three months ago |
| v22 | **2025-10-21** | 2027-04-30 — already in maintenance |
| v24 | 2026-10-20 | **2028-04-30** — current Active LTS |

Moving to 22 would land on a line that entered maintenance nine months ago and need redoing within the year.

## Scope

**33 pins across 14 files** — 22 Dockerfile `FROM` lines, 8 workflow `node-version` entries (both quote styles preserved), the docker-compose example, and the copilot-studio doc snippet that mirrors `Dockerfile.mcp-proxy`. The root `Dockerfile` was already `node:22-slim` and stays slim rather than converting to alpine.

No dependency constrains the major. The only node-gyp package (`bcrypt`) ships N-API prebuilds, so nothing needs rebuilding.

## Verification

`npx turbo build` — **13/13 successful** on Node 24.3.0 locally. CI exercises the workflow pins; the Dockerfiles get exercised on deploy.

## Deliberately excluded

Kept out so the runtime bump stays independently revertable: `@types/node` `^20` → `^24` across six package.json files, `integrations/github-action` `using: 'node20'`, and the `engines` floors on the published packages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)