### PR TITLE
fix(api): preserve @sidclaw/shared subpath exports in the production image [OUTAGE]

### DIFF
--- a/apps/api/Dockerfile
+++ b/apps/api/Dockerfile
@@ -43,14 +43,26 @@ RUN npm ci --workspace=apps/api --workspace=packages/shared --omit=dev --ignore-
 # Rebuild shared as CommonJS for Node.js runtime compatibility
 # (source uses moduleResolution:bundler which allows directory imports,
 # but Node.js ESM doesn't support them)
+#
+# Every subpath in the source exports map is remapped, not just '.'. This step
+# previously hardcoded a single '.' entry, which silently dropped every subpath
+# export — so `import from '@sidclaw/shared/scopes'` typechecked, built, passed
+# CI, and then threw ERR_PACKAGE_PATH_NOT_EXPORTED at container start. Deriving
+# the map from the source means a new subpath cannot reintroduce that.
 RUN cd packages/shared && rm -rf dist && \
   find src -name '*.test.ts' -delete && \
   npx tsc --outDir dist --module commonjs --moduleResolution node --declaration --sourceMap --esModuleInterop && \
   node -e "\
     const fs = require('fs'); \
     const pkg = JSON.parse(fs.readFileSync('package.json', 'utf8')); \
+    const toDist = (p, ext) => p.replace('./src/', './dist/').replace('.ts', ext); \
+    const out = {}; \
+    for (const [key, val] of Object.entries(pkg.exports || {})) { \
+      out[key] = { types: toDist(val.types, '.d.ts'), default: toDist(val.default, '.js') }; \
+    } \
+    pkg.exports = out; \
     pkg.main = './dist/index.js'; \
-    pkg.exports = { '.': { types: './dist/index.d.ts', default: './dist/index.js' } }; \
+    pkg.types = './dist/index.d.ts'; \
     delete pkg.type; \
     fs.writeFileSync('package.json', JSON.stringify(pkg, null, 2));"
 


### PR DESCRIPTION
## 🔴 Production outage — `api.sidclaw.com` has returned 502 since 09:58 UTC

The API container crashes at start:

```
Error [ERR_PACKAGE_PATH_NOT_EXPORTED]: Package subpath './scopes' is not
defined by "exports" in /app/node_modules/@sidclaw/shared/package.json
imported from /app/apps/api/dist/middleware/auth.js
```

**This is my regression from #65 (scope model), not #66 (Node 24).** The identical crash appears in the `ccfff17` deploy running Node 20.20.2 — one commit *before* the runtime change.

## Cause

`apps/api/Dockerfile` rebuilds `packages/shared` as CommonJS for the production runtime and rewrites its `package.json`. That rewrite hardcoded a single entry:

```js
pkg.exports = { '.': { types: './dist/index.d.ts', default: './dist/index.js' } };
```

Every subpath export was discarded at image-build time. So `@sidclaw/shared/scopes` typechecked, built, and passed **all 11 CI checks** — including `test-api`, which runs against source, not the built image — then failed at container start.

## Fix

Derives the exports map from the source rather than hardcoding, remapping `./src/*.ts` → `./dist/*.js` / `./dist/*.d.ts`. Adding a subpath can no longer silently break the runtime. Verified against the real `package.json` before committing — all three entries remap correctly.

Only `apps/api` does this rewrite; the dashboard transpiles shared from source via Next `transpilePackages`, which is why its build was unaffected.

## The gap this exposes

**CI builds no Docker image and boots no container.** This entire class of failure is invisible to it — the pipeline validates source, and production runs an artifact assembled by a different set of rules. Worth closing separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)