### PR TITLE
fix(sdk): declare @modelcontextprotocol/sdk as a devDependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16758,7 +16758,7 @@
     },
     "packages/cli": {
       "name": "@sidclaw/cli",
-      "version": "0.1.1",
+      "version": "0.1.2",
       "license": "MIT",
       "bin": {
         "sidclaw": "bin/sidclaw.mjs"
@@ -16876,7 +16876,7 @@
     },
     "packages/openclaw-plugin": {
       "name": "@sidclaw/openclaw-plugin",
-      "version": "0.3.1",
+      "version": "0.3.2",
       "license": "MIT",
       "devDependencies": {
         "@sidclaw/sdk": "^0.1.10",
@@ -16889,7 +16889,7 @@
         "node": ">=18"
       },
       "peerDependencies": {
-        "@sidclaw/sdk": "^0.1.11",
+        "@sidclaw/sdk": "^0.1.12",
         "openclaw": ">=2026.4.0"
       },
       "peerDependenciesMeta": {
@@ -16970,12 +16970,13 @@
     },
     "packages/sdk": {
       "name": "@sidclaw/sdk",
-      "version": "0.1.11",
+      "version": "0.1.13",
       "license": "Apache-2.0",
       "bin": {
         "sidclaw-mcp-proxy": "bin/sidclaw-mcp-proxy.cjs"
       },
       "devDependencies": {
+        "@modelcontextprotocol/sdk": "^1.0.0",
         "@sidclaw/shared": "*",
         "tsup": "^8.5.1",
         "typescript": "^5.9.3",

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -208,6 +208,7 @@
     "url": "https://github.com/sidclawhq/platform/issues"
   },
   "devDependencies": {
+    "@modelcontextprotocol/sdk": "^1.0.0",
     "@sidclaw/shared": "*",
     "tsup": "^8.5.1",
     "typescript": "^5.9.3",


### PR DESCRIPTION
`demo-atlas` has failed to build since the Node 24 bump:

```
src/mcp/governance-server.ts(1,24): error TS2307: Cannot find module
'@modelcontextprotocol/sdk/server/index.js' or its corresponding type declarations.
(×5, plus 6 implicit-any errors that follow)
Error: error occurred in dts build
```

The live demos are still up — Railway is serving the last good deploy (`ccfff17`, 09:58) — but every build since has failed.

## Cause

`packages/sdk/src/mcp/governance-server.ts` imports `@modelcontextprotocol/sdk` in **five** places, and the tsup dts build typechecks that file. So the package's own build requires those types.

But the SDK declared it **only as an optional `peerDependency`**. The types resolved purely because a sibling workspace — `packages/mcp-tools` — declares it as a real dependency, and npm hoisted it to the root.

`apps/demo/Dockerfile` copies only `packages/shared/package.json` and `packages/sdk/package.json`, **not** `packages/mcp-tools/package.json`. Under npm 10 (Node 20) the hoisted copy got installed anyway; under npm 11 (Node 24) it does not.

So the Node bump didn't break the build — it removed the accident that was holding it up.

## Fix

Declare it as a `devDependency` so the SDK's build is self-sufficient rather than dependent on which sibling workspaces happen to be present.

It stays an optional `peerDependency` for consumers — **nothing changes for anyone installing `@sidclaw/sdk`**, since devDependencies aren't installed transitively.

## Verification

Lockfile records it for `packages/sdk`; `npm run build` in `packages/sdk` completes including the dts step that was failing.

Also unblocks `demo-devops` and `demo-healthcare`, whose Dockerfiles copy the same subset of workspace manifests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)