### PR TITLE
ci: build every production image and boot the API container

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -154,3 +154,110 @@ jobs:
             echo "ERROR: Bundle size exceeds 250KB"
             exit 1
           fi
+
+  # ── Production-artifact checks ────────────────────────────────────────────
+  #
+  # Everything above validates SOURCE inside a complete workspace. Production
+  # builds a SUBSET of workspaces into an image whose package manifests are
+  # rewritten by the Dockerfile. Nothing exercised that second environment, and
+  # on 2026-07-28 two independent outages came from the gap within 20 minutes:
+  #
+  #   1. apps/api/Dockerfile rewrote packages/shared's exports map to a single
+  #      '.' entry, silently dropping the './scopes' subpath. The import
+  #      typechecked, built, and passed all 11 checks, then threw
+  #      ERR_PACKAGE_PATH_NOT_EXPORTED at container start. API 502 for 13 min.
+  #   2. packages/sdk's dts build needs @modelcontextprotocol/sdk types but
+  #      declared it only as an optional peer; it resolved because a sibling
+  #      workspace hoisted it. The demo Dockerfiles do not copy that manifest,
+  #      so their builds broke while CI stayed green.
+  #
+  # Job 1 catches build-time breaks like (2). Job 2 catches runtime breaks like
+  # (1) — building the image is not enough, the container has to actually boot.
+
+  docker-images:
+    name: docker-images (${{ matrix.image.name }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        image:
+          - { name: api, file: apps/api/Dockerfile }
+          - { name: dashboard, file: apps/dashboard/Dockerfile }
+          - { name: docs, file: apps/docs/Dockerfile }
+          - { name: landing, file: apps/landing/Dockerfile }
+          - { name: demo-atlas, file: apps/demo/Dockerfile }
+          - { name: demo-devops, file: apps/demo-devops/Dockerfile }
+          - { name: demo-healthcare, file: apps/demo-healthcare/Dockerfile }
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435 # v3.11.1
+      - name: Build ${{ matrix.image.name }} image
+        uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 # v6.18.0
+        with:
+          context: .
+          file: ${{ matrix.image.file }}
+          push: false
+          load: false
+          cache-from: type=gha,scope=${{ matrix.image.name }}
+          cache-to: type=gha,mode=max,scope=${{ matrix.image.name }}
+
+  api-container-boots:
+    runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: postgres:16-alpine
+        env:
+          POSTGRES_DB: agent_identity_test
+          POSTGRES_USER: agent_identity
+          POSTGRES_PASSWORD: agent_identity
+        ports:
+          - 5433:5432
+        options: >-
+          --health-cmd "pg_isready -U agent_identity"
+          --health-interval 5s
+          --health-timeout 3s
+          --health-retries 5
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435 # v3.11.1
+      - name: Build the API image locally
+        uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 # v6.18.0
+        with:
+          context: .
+          file: apps/api/Dockerfile
+          push: false
+          load: true
+          tags: sidclaw-api:ci
+          cache-from: type=gha,scope=api
+      - name: Boot the container
+        run: |
+          docker run -d --name api-ci --network host \
+            -e DATABASE_URL="postgresql://agent_identity:agent_identity@localhost:5433/agent_identity_test" \
+            -e NODE_ENV=production \
+            -e PORT=4000 \
+            sidclaw-api:ci
+      - name: Wait for /health
+        run: |
+          for i in $(seq 1 40); do
+            code=$(curl -s -o /dev/null -w '%{http_code}' http://localhost:4000/health || echo 000)
+            if [ "$code" = "200" ]; then
+              echo "Container healthy after ${i} attempt(s):"
+              curl -s http://localhost:4000/health
+              echo
+              exit 0
+            fi
+            # Fail fast if the container already died — no point waiting out
+            # the full timeout on a crash loop.
+            if [ -z "$(docker ps -q -f name=api-ci)" ]; then
+              echo "::error::API container exited before becoming healthy"
+              docker logs api-ci
+              exit 1
+            fi
+            sleep 3
+          done
+          echo "::error::API container never became healthy"
+          docker logs api-ci
+          exit 1
+      - name: Container logs
+        if: always()
+        run: docker logs api-ci 2>&1 | tail -40

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -231,10 +231,19 @@ jobs:
           cache-from: type=gha,scope=api
       - name: Boot the container
         run: |
+          # NODE_ENV=production deliberately: the point is to exercise the
+          # production boot path, which fails fast on missing config
+          # (server.ts:17-33). SESSION_SECRET must be >=32 chars, and
+          # PUBLIC_API_URL is mandatory because /tenant/info embeds it —
+          # deriving it from headers under trustProxy would be a
+          # host-header-injection primitive. Throwaway values; this container
+          # is destroyed with the runner.
           docker run -d --name api-ci --network host \
             -e DATABASE_URL="postgresql://agent_identity:agent_identity@localhost:5433/agent_identity_test" \
             -e NODE_ENV=production \
             -e PORT=4000 \
+            -e SESSION_SECRET="ci-smoke-test-session-secret-not-a-real-secret-0123456789" \
+            -e PUBLIC_API_URL="http://localhost:4000" \
             sidclaw-api:ci
       - name: Wait for /health
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -238,25 +238,33 @@ jobs:
             sidclaw-api:ci
       - name: Wait for /health
         run: |
-          for i in $(seq 1 40); do
+          # The container runs `prisma migrate deploy` before starting the
+          # server, which takes ~15s on a fresh database, so it is legitimately
+          # not listening for a while. Ask docker for the container's actual
+          # state rather than inferring death from `docker ps` — an earlier
+          # version of this step used `docker ps -q -f name=...` and reported
+          # a crash while the container was still applying migrations.
+          for i in $(seq 1 60); do
             code=$(curl -s -o /dev/null -w '%{http_code}' http://localhost:4000/health || echo 000)
             if [ "$code" = "200" ]; then
-              echo "Container healthy after ${i} attempt(s):"
+              echo "Container healthy after ${i} attempt(s) (~$((i * 3))s):"
               curl -s http://localhost:4000/health
               echo
               exit 0
             fi
-            # Fail fast if the container already died — no point waiting out
-            # the full timeout on a crash loop.
-            if [ -z "$(docker ps -q -f name=api-ci)" ]; then
-              echo "::error::API container exited before becoming healthy"
-              docker logs api-ci
-              exit 1
-            fi
+            state=$(docker inspect -f '{{.State.Status}}' api-ci 2>/dev/null || echo missing)
+            case "$state" in
+              exited|dead|missing)
+                echo "::error::API container is '$state' before becoming healthy"
+                docker inspect -f 'exit code: {{.State.ExitCode}}' api-ci 2>/dev/null || true
+                docker logs api-ci 2>&1 | tail -60
+                exit 1
+                ;;
+            esac
             sleep 3
           done
-          echo "::error::API container never became healthy"
-          docker logs api-ci
+          echo "::error::API container never became healthy within 180s (last state: $state)"
+          docker logs api-ci 2>&1 | tail -60
           exit 1
       - name: Container logs
         if: always()


### PR DESCRIPTION
Everything CI checked until now validates **source inside a complete workspace**. Production builds a **subset of workspaces into an image whose package manifests are rewritten by the Dockerfile**. Nothing exercised that second environment.

Today two independent outages came out of that gap within 20 minutes — both after passing all 11 checks.

| # | What broke | Why CI missed it |
|---|---|---|
| 1 | `apps/api/Dockerfile` rewrites `packages/shared`'s `package.json` and hardcoded `exports` to a single `'.'` entry, discarding the `./scopes` subpath from #65 | `test-api` runs against **source**. The failure was `ERR_PACKAGE_PATH_NOT_EXPORTED` at *container start*. **api.sidclaw.com 502 for 13 minutes.** |
| 2 | `packages/sdk`'s dts build typechecks five `@modelcontextprotocol/sdk` imports but declared it only as an optional peer — it resolved via a sibling workspace's hoist | The demo Dockerfiles don't copy that manifest. Under npm 11 their builds broke while CI stayed green. |

## Two jobs, because building isn't sufficient

**`docker-images`** — builds all 7 production images in a matrix, `fail-fast: false`, per-image gha cache. Catches build-time breaks like (2), *including in the demos*, whose Dockerfiles copy a narrower set of manifests than the API's and therefore fail differently.

**`api-container-boots`** — builds the API image, runs it against a throwaway Postgres, polls `/health` until 200. Catches runtime breaks like (1), which a successful build **cannot**. Exits early if the container dies rather than waiting out the timeout, and always dumps logs.

## Notes

- Both `docker/*` actions are pinned to commit SHAs **verified against the GitHub ref API**, not copied from memory.
- This adds real minutes to CI. That's the correct trade — these are the only checks in the pipeline that look at what actually ships.
- This PR is its own first test: if either job is misconfigured, it fails here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)