### PR TITLE
DO NOT MERGE: mutation test for api-container-boots

### DIFF
--- a/apps/api/Dockerfile
+++ b/apps/api/Dockerfile
@@ -55,12 +55,7 @@ RUN cd packages/shared && rm -rf dist && \
   node -e "\
     const fs = require('fs'); \
     const pkg = JSON.parse(fs.readFileSync('package.json', 'utf8')); \
-    const toDist = (p, ext) => p.replace('./src/', './dist/').replace('.ts', ext); \
-    const out = {}; \
-    for (const [key, val] of Object.entries(pkg.exports || {})) { \
-      out[key] = { types: toDist(val.types, '.d.ts'), default: toDist(val.default, '.js') }; \
-    } \
-    pkg.exports = out; \
+    pkg.exports = { '.': { types: './dist/index.d.ts', default: './dist/index.js' } }; \
     pkg.main = './dist/index.js'; \
     pkg.types = './dist/index.d.ts'; \
     delete pkg.type; \


### PR DESCRIPTION
Throwaway. Reintroduces the exports-map bug fixed in #67 to prove `api-container-boots` actually catches it. Expected: that job FAILS with ERR_PACKAGE_PATH_NOT_EXPORTED while everything else passes. Will be closed and deleted.