### PR TITLE
docs: honest integrity claims + fix stale demo instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ Four primitives govern every agent action:
 │ agent    │    │ action   │    │ actions  │    │ decision │
 │ has an   │    │ evaluated│    │ get human│    │ creates  │
 │ owner &  │    │ against  │    │ review   │    │ tamper-  │
-│ scoped   │    │ explicit │    │ with rich│    │ proof    │
+│ scoped   │    │ explicit │    │ with rich│    │ evident  │
 │ perms    │    │ rules    │    │ context  │    │ audit    │
 └──────────┘    └──────────┘    └──────────┘    └──────────┘
 ```

--- a/README.md
+++ b/README.md
@@ -22,18 +22,13 @@ Works with MCP, LangChain, OpenAI Agents, Claude Agent SDK, and 15+ more.
 
 Your agents call tools without oversight. SidClaw intercepts every tool call, checks it against your policies, and holds risky actions for human review before they execute.
 
-### Try it locally (self-contained, no install)
-
-Clone and run:
+### Try it locally (10 seconds, no signup)
 
 ```bash
-git clone https://github.com/sidclawhq/platform
-cd platform/packages/sidclaw-demo && node cli.mjs
+npx sidclaw-demo
 ```
 
 Opens a local governance dashboard at `http://localhost:3030` with four pre-loaded scenarios (Claude Code `rm -rf`, fintech trade, DevOps scale-to-zero, clinical lab order). No signup, no Docker, no API key — just the approval card UX running in your browser.
-
-> **Coming to npm soon**: `npx sidclaw-demo` one-liner will be published alongside the next SDK release. Until then, the clone-and-run path above is the canonical way to see the demo.
 
 ### See it in action
 
@@ -361,7 +356,7 @@ SidClaw maps to regulatory requirements across the US, EU, Switzerland, and Sing
 ### For Security & Compliance Teams
 - **Policy engine** — allow / approval_required / deny with priority ordering and classification hierarchy
 - **Approval workflow** — context-rich cards with agent reasoning, risk classification, and separation of duties
-- **Audit trails** — correlated traces with integrity hash chains (tamper-proof)
+- **Audit trails** — correlated traces with integrity hash chains (tamper-evident)
 - **SIEM export** — JSON and CSV, continuous webhook delivery
 
 ### For Platform Teams

--- a/apps/dashboard/src/components/architecture/ControlArchitectureDiagram.tsx
+++ b/apps/dashboard/src/components/architecture/ControlArchitectureDiagram.tsx
@@ -36,7 +36,7 @@ const NODE_DESCRIPTIONS: Record<string, string> = {
     "Routes high-risk actions to human reviewers with rich context",
   integ:
     "External services the agent is permitted to access after authorization",
-  trace: "Immutable log of every evaluation, decision, and outcome",
+  trace: "Tamper-evident log of every evaluation, decision, and outcome",
 };
 
 const EDGE_DESCRIPTIONS: Record<string, string> = {

--- a/apps/docs/content/docs/api-reference/traces.mdx
+++ b/apps/docs/content/docs/api-reference/traces.mdx
@@ -5,7 +5,7 @@ description: Query, export, and verify the integrity of audit traces that record
 
 # Trace Endpoints
 
-Every call to `/evaluate` creates an audit trace -- a complete, immutable record of the governance decision lifecycle. Traces contain ordered events covering identity resolution, policy evaluation, approval decisions, and execution outcomes. Each event is integrity-hashed to form a tamper-evident chain.
+Every call to `/evaluate` creates an audit trace -- a complete, append-only record of the governance decision lifecycle. Traces contain ordered events covering identity resolution, policy evaluation, approval decisions, and execution outcomes. Each event is integrity-hashed to form a tamper-evident chain.
 
 ## Endpoint Summary
 
@@ -258,6 +258,8 @@ curl -X POST http://localhost:4000/api/v1/traces/550e8400-e29b-41d4-a716-4466554
 ## GET /api/v1/traces/:traceId/verify
 
 Verify the integrity of a trace's event hash chain. Each event contains a SHA-256 hash that chains to the previous event, forming a tamper-evident log.
+
+Verification detects modification, insertion, reordering, or mid-chain deletion of events. It does not detect truncation — removal of the most recent events leaves a valid shorter chain — or deletion of an entire trace. To detect truncation, compare against trace exports retained outside the platform.
 
 **Auth:** API key with `traces:read` scope, or any authenticated session.
 

--- a/apps/docs/content/docs/compliance/eu-ai-act.mdx
+++ b/apps/docs/content/docs/compliance/eu-ai-act.mdx
@@ -61,7 +61,7 @@ High-risk AI systems must have automatic logging capabilities. Logs must record:
 - Which policy matched and what version was in effect
 - What the outcome was and who was involved in the decision
 
-**Integrity Hashes** — Each audit event is protected by a SHA-256 hash chain. The hash of each event incorporates the hash of the previous event, creating a tamper-proof sequence. This provides cryptographic guarantees that records have not been modified after the fact, exceeding Article 12's implicit requirement for reliable logging.
+**Integrity Hashes** — Each audit event is protected by a SHA-256 hash chain. The hash of each event incorporates the hash of the previous event, creating a tamper-evident sequence: modification, insertion, or mid-chain deletion of recorded events is cryptographically detectable via [trace verification](/docs/concepts/traces#integrity-hashes). Truncation of a trace's most recent events is not detectable by the chain alone — pair verification with scheduled exports retained outside the platform for a complete integrity posture.
 
 **Trace Verification** — The `GET /api/v1/traces/:traceId/verify` endpoint validates the integrity of any trace's hash chain. Auditors can verify that records are complete and unmodified.
 
@@ -158,5 +158,5 @@ For SMEs and startups, the lower of the two figures (fixed amount vs. turnover p
 - [EU AI Act Article 13 — Transparency](https://artificialintelligenceact.eu/article/13/)
 - [EU AI Act Article 14 — Human Oversight](https://artificialintelligenceact.eu/article/14/)
 - [SidClaw Approval Workflows](/docs/concepts/approval) — the human oversight primitive
-- [SidClaw Audit Traces](/docs/concepts/traces) — tamper-proof record-keeping
+- [SidClaw Audit Traces](/docs/concepts/traces) — tamper-evident record-keeping
 - [SIEM Export](/docs/enterprise/siem-export) — export for compliance archival

--- a/apps/docs/content/docs/compliance/finra-2026.mdx
+++ b/apps/docs/content/docs/compliance/finra-2026.mdx
@@ -86,7 +86,7 @@ Logging AI agent actions and decisions, implementing guardrails. Firms must main
 
 Each event is timestamped, attributed to an actor (agent, system, or human), and linked to the parent trace for full correlation.
 
-**Integrity Hashes** — Every audit event is protected by a SHA-256 hash chain. Each event's hash includes the previous event's hash, creating a tamper-proof chain that can be independently verified. If any event is modified or deleted, the chain breaks and verification fails. This satisfies FINRA's implicit requirement for reliable, unmodifiable records.
+**Integrity Hashes** — Every audit event is protected by a SHA-256 hash chain. Each event's hash includes the previous event's hash, creating a tamper-evident chain that can be independently verified. If an event is modified, inserted, or deleted from the middle of a trace, the chain breaks and verification fails. The chain does not detect truncation of a trace's most recent events; combine verification with scheduled off-platform exports to evidence completeness as well as integrity.
 
 **Trace Verification API** — The `GET /api/v1/traces/:traceId/verify` endpoint validates the hash chain integrity of any trace. Compliance teams and auditors can programmatically verify that audit records have not been tampered with.
 
@@ -119,4 +119,4 @@ Use this checklist to verify your SidClaw configuration meets FINRA 2026 require
 - [Agent Registry](/docs/concepts/identity) — how SidClaw models agent identity
 - [Policy Engine](/docs/concepts/policy) — how policies evaluate agent actions
 - [Approval Workflows](/docs/concepts/approval) — the human-in-the-loop primitive
-- [Audit Traces](/docs/concepts/traces) — tamper-proof event chains
+- [Audit Traces](/docs/concepts/traces) — tamper-evident event chains

--- a/apps/docs/content/docs/concepts/traces.mdx
+++ b/apps/docs/content/docs/concepts/traces.mdx
@@ -1,11 +1,11 @@
 ---
 title: Audit Traces
-description: Tamper-proof chronological event chains for every evaluated agent action.
+description: Tamper-evident chronological event chains for every evaluated agent action.
 ---
 
 # Audit Traces
 
-Every action evaluated by SidClaw produces an audit trace — a chronological chain of events that records exactly what happened, from the moment the action was submitted through policy evaluation, approval (if needed), and final outcome. Traces are tamper-proof, exportable, and designed for compliance.
+Every action evaluated by SidClaw produces an audit trace — a chronological chain of events that records exactly what happened, from the moment the action was submitted through policy evaluation, approval (if needed), and final outcome. Traces are tamper-evident, exportable, and designed for compliance.
 
 ## Trace Structure
 
@@ -94,7 +94,9 @@ The `final_outcome` field on the trace records the overall result:
 
 ## Integrity Hashes
 
-Every audit event in a trace is linked to its predecessor by a SHA-256 hash chain. This makes the audit trail tamper-proof — if any event is modified, deleted, or inserted after the fact, the hash chain breaks and verification fails.
+Every audit event in a trace is linked to its predecessor by a SHA-256 hash chain. This makes the audit trail tamper-evident — if an event in the chain is modified, inserted, reordered, or deleted from the middle of a trace after the fact, the hash chain breaks and verification fails.
+
+> **What the chain does not detect:** the chain has no sealed length, so removing the *most recent* events of a trace leaves a valid shorter chain that still verifies, and deleting an entire trace leaves nothing to verify. In practice this means a database restored from an older backup will pass verification while missing everything recorded after the backup point. If your compliance posture requires detecting truncation, export traces on a schedule (see [Audit export](/docs/platform/audit)) and retain the exports outside the platform — a divergence between an export and the live system is your truncation signal.
 
 The hash is computed over:
 - The event's ID, trace ID, event type, actor, description, status, and timestamp

--- a/apps/docs/content/docs/index.mdx
+++ b/apps/docs/content/docs/index.mdx
@@ -19,7 +19,7 @@ SidClaw is built on four primitives that form a chain: **Identity, Policy, Appro
 
 **Approval** — The core differentiator. When a policy evaluates to `approval_required`, SidClaw creates a context-rich approval card showing what the agent wants to do, why it was flagged, the risk classification, and the agent's reasoning. A human reviewer approves or denies. Separation of duties ensures agent owners cannot approve their own agent's requests. [Learn more](/docs/concepts/approval)
 
-**Trace** — Every evaluated action produces a tamper-proof audit trail. Each trace is a chronological chain of events — from initiation through identity resolution, policy evaluation, approval (if needed), and final outcome. SHA-256 hash chains guarantee integrity. [Learn more](/docs/concepts/traces)
+**Trace** — Every evaluated action produces a tamper-evident audit trail. Each trace is a chronological chain of events — from initiation through identity resolution, policy evaluation, approval (if needed), and final outcome. SHA-256 hash chains make after-the-fact modification of recorded events detectable. [Learn more](/docs/concepts/traces)
 
 ## How It Works
 

--- a/apps/docs/content/docs/integrations/openclaw.mdx
+++ b/apps/docs/content/docs/integrations/openclaw.mdx
@@ -88,4 +88,4 @@ The ClawHavoc campaign discovered 1,184 malicious skills on ClawHub. SidClaw add
 - Policy-based evaluation of every tool call
 - Human approval for high-risk actions
 - Complete audit trail
-- Tamper-proof integrity hashing
+- Tamper-evident integrity hashing

--- a/apps/docs/content/docs/platform/audit.mdx
+++ b/apps/docs/content/docs/platform/audit.mdx
@@ -1,6 +1,6 @@
 ---
 title: Audit & Traces
-description: Every agent action creates an immutable audit trace with a chain of events. View, filter, verify integrity, and export traces for compliance.
+description: Every agent action creates a tamper-evident audit trace with a chain of events. View, filter, verify integrity, and export traces for compliance.
 ---
 
 # Audit & Traces
@@ -109,7 +109,7 @@ Each event includes:
 
 ## Integrity verification
 
-Every audit event is hashed and chained to the previous event in the trace, creating a tamper-evident record. You can verify the integrity of any trace.
+Every audit event is hashed and chained to the previous event in the trace, creating a tamper-evident record. You can verify the integrity of any trace. Verification detects events that were modified, inserted, reordered, or removed from the middle of a trace — it cannot detect removal of a trace's most recent events or deletion of a whole trace, so pair it with scheduled exports retained outside the platform (see [Export](#export)).
 
 ```bash
 curl https://api.sidclaw.com/api/v1/traces/{traceId}/verify \

--- a/docs/compliance/eu-ai-act.json
+++ b/docs/compliance/eu-ai-act.json
@@ -90,7 +90,7 @@
       "coverage": "partial",
       "sidclaw_features": [
         "Policy versioning with modified_by and change_summary — documented change-management process",
-        "Immutable audit trail of every policy change supports QMS evidence requirements",
+        "Tamper-evident audit trail of every policy change supports QMS evidence requirements",
         "Plan-level controls and RBAC enforce documented role responsibilities",
         "Export endpoints provide evidence bundles for internal QMS reviews and external conformity assessments"
       ],

--- a/docs/compliance/finra-2026.json
+++ b/docs/compliance/finra-2026.json
@@ -84,7 +84,7 @@
       "coverage": "partial",
       "sidclaw_features": [
         "Trace retention configurable per plan (7 / 30 / 90 days; enterprise custom, supporting multi-year retention)",
-        "Immutable hash-chained events prevent covert modification of retained records",
+        "Tamper-evident hash-chained events make covert modification of retained records detectable",
         "JSON and CSV export for long-term archival in WORM-compliant storage",
         "SIEM export for continuous forwarding to regulated retention systems"
       ],

--- a/docs/compliance/soc2.json
+++ b/docs/compliance/soc2.json
@@ -67,7 +67,7 @@
       "sidclaw_features": [
         "Policy versioning — every change creates a PolicyRuleVersion with modified_by + change_summary",
         "Deployment governance via the GitHub Action — workflows can be gated by SidClaw approval Check Runs",
-        "Immutable audit trail of policy changes (hash-chained)"
+        "Tamper-evident audit trail of policy changes (hash-chained)"
       ]
     },
     {

--- a/packages/openclaw-skill/README.md
+++ b/packages/openclaw-skill/README.md
@@ -8,7 +8,7 @@ SidClaw evaluates every MCP tool call against your security policies:
 - **Allowed** actions execute instantly
 - **High-risk** actions require human approval before execution
 - **Prohibited** actions are blocked before any data is accessed
-- Every decision is logged with a tamper-proof audit trail
+- Every decision is logged with a tamper-evident audit trail
 
 ## Why you need this
 


### PR DESCRIPTION
## What

**1. Integrity claims now match what the code does.**
`verifyTrace` (apps/api/src/services/integrity-service.ts) detects modification, insertion, reordering, and mid-chain deletion — but the chain has no sealed length, so removing a trace's *most recent* events leaves a valid shorter chain that returns `verified: true`, and deleting a whole trace is invisible. A database restored from an older backup passes verification while missing everything after the backup point.

Docs claimed the opposite. Changes across 13 files:
- `tamper-proof` / `immutable` → `tamper-evident` everywhere (docs, README, dashboard architecture diagram, compliance JSON bundles, OpenClaw skill README)
- concepts/traces, platform/audit, api-reference/traces: explicit statement of what verification does and does not detect, with off-platform exports recommended as the completeness control
- EU AI Act page: removed 'cryptographic guarantees that records have not been modified'; FINRA page: removed 'unmodifiable records' + the specific false 'modified or deleted → verification fails' sentence

**2. README quick start unblocked.**
Deleted the '**Coming to npm soon**: npx sidclaw-demo' note — the package shipped 2026-04-17. Quick start is now `npx sidclaw-demo` (smoke-tested from the public registry today: HTTP 200 on the dashboard, clean banner). Clone-and-run demoted out of existence; the self-host clone path at line ~430 is untouched.

## Verification
- `apps/docs` production build passes with the MDX edits
- Both `npx sidclaw-demo --no-open` and `npx sidclaw-mcp-guard demo` verified working from the registry as a stranger would run them

🤖 Generated with [Claude Code](https://claude.com/claude-code)