### PR TITLE
chore: commit MCP registry server.json at v0.1.13

### DIFF
--- a/server.json
+++ b/server.json
@@ -1,0 +1,52 @@
+{
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+  "name": "io.github.VladUZH/sidclaw-governance-mcp",
+  "description": "Governance proxy for MCP servers — policy evaluation, human approval, audit trails.",
+  "repository": {
+    "url": "https://github.com/sidclawhq/platform",
+    "source": "github"
+  },
+  "version": "0.1.13",
+  "packages": [
+    {
+      "registryType": "npm",
+      "identifier": "@sidclaw/sdk",
+      "version": "0.1.13",
+      "transport": {
+        "type": "stdio"
+      },
+      "environmentVariables": [
+        {
+          "description": "SidClaw API key for policy evaluation and audit logging",
+          "isRequired": true,
+          "format": "string",
+          "isSecret": true,
+          "name": "SIDCLAW_API_KEY"
+        },
+        {
+          "description": "Agent identity for policy matching and audit trails",
+          "isRequired": true,
+          "format": "string",
+          "name": "SIDCLAW_AGENT_ID"
+        },
+        {
+          "description": "Command for the upstream MCP server (e.g., npx)",
+          "isRequired": true,
+          "format": "string",
+          "name": "SIDCLAW_UPSTREAM_CMD"
+        },
+        {
+          "description": "Comma-separated args for the upstream MCP server",
+          "isRequired": true,
+          "format": "string",
+          "name": "SIDCLAW_UPSTREAM_ARGS"
+        },
+        {
+          "description": "Approval mode: error (default, returns immediately) or block (waits for approval)",
+          "format": "string",
+          "name": "SIDCLAW_APPROVAL_MODE"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
The MCP registry entry has been frozen at 0.1.7 since April 2 — anyone discovering SidClaw through registry.modelcontextprotocol.io installs code seven releases stale. The manifest was never in the repo, so republishing meant reconstructing it by hand each time.

This commits it, reconstructed from the live registry entry with versions bumped to `@sidclaw/sdk@0.1.13`. Env vars verified against the current proxy CLI. `@sidclaw/sdk@0.1.13` on npm already carries the matching `mcpName` field, so registry ownership validation passes.

**Publishing needs your GitHub login** (the entry lives under the `io.github.VladUZH` namespace). After merging:

```bash
brew install mcp-publisher
mcp-publisher login github   # device-code flow, log in as VladUZH
mcp-publisher publish        # from the repo root, reads server.json
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)