### PR TITLE
fix: scope-model leftovers — fail-closed key default, --setup-key, docs vocabulary

### DIFF
--- a/apps/api/prisma/migrations/20260728120000_api_key_scopes_default_empty/migration.sql
+++ b/apps/api/prisma/migrations/20260728120000_api_key_scopes_default_empty/migration.sql
@@ -1,0 +1,5 @@
+-- Fail-closed default for ApiKey.scopes: a key created without explicit
+-- scopes must grant nothing, not everything. Existing rows are deliberately
+-- untouched — legacy seed keys carrying '["*"]' are handled (and logged) by
+-- the auth middleware; rewriting live credentials is a separate operation.
+ALTER TABLE "ApiKey" ALTER COLUMN "scopes" SET DEFAULT '[]';

--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -266,7 +266,11 @@ model ApiKey {
   name          String
   key_prefix    String
   key_hash      String    @unique
-  scopes        Json      @default("[\"*\"]")
+  // Fail-closed: a key created without explicit scopes can do nothing.
+  // (Was '["*"]' — any code path that forgot to pass scopes silently minted
+  // an all-powerful key. Every current creation path passes scopes explicitly,
+  // so this default is only ever hit by mistakes; make mistakes powerless.)
+  scopes        Json      @default("[]")
   expires_at    DateTime?
   last_used_at  DateTime?
   created_at    DateTime  @default(now())

--- a/apps/docs/content/docs/api-reference/agents.mdx
+++ b/apps/docs/content/docs/api-reference/agents.mdx
@@ -25,7 +25,7 @@ Agents are the AI entities governed by SidClaw. Each agent has an identity profi
 
 Create a new agent registration.
 
-**Auth:** API key with `admin` scope, or session with `admin` role.
+**Auth:** API key with `agents:write` scope, or session with `admin` role.
 
 ### Request Body
 
@@ -117,7 +117,7 @@ curl -X POST http://localhost:4000/api/v1/agents \
 |---|---|---|
 | `400` | `validation_error` | Invalid or missing fields |
 | `401` | `unauthorized` | Authentication required |
-| `403` | `forbidden` | Admin role/scope required |
+| `403` | `forbidden` | Required scope (`agents:write` / `agents:lifecycle`) or admin role missing |
 
 ---
 
@@ -210,7 +210,7 @@ curl http://localhost:4000/api/v1/agents/550e8400-e29b-41d4-a716-446655440000 \
 
 Update an agent's metadata fields.
 
-**Auth:** API key with `admin` scope, or session with `admin` role.
+**Auth:** API key with `agents:write` scope, or session with `admin` role.
 
 ### Path Parameters
 
@@ -252,7 +252,7 @@ curl -X PATCH http://localhost:4000/api/v1/agents/550e8400-e29b-41d4-a716-446655
 
 | Status | Error | Description |
 |---|---|---|
-| `403` | `forbidden` | Admin role/scope required |
+| `403` | `forbidden` | Required scope (`agents:write` / `agents:lifecycle`) or admin role missing |
 | `404` | `not_found` | Agent does not exist |
 
 ---
@@ -261,7 +261,7 @@ curl -X PATCH http://localhost:4000/api/v1/agents/550e8400-e29b-41d4-a716-446655
 
 Suspend an active agent. Suspended agents cannot pass policy evaluation.
 
-**Auth:** API key with `admin` scope, or session with `admin` role.
+**Auth:** API key with `agents:lifecycle` scope, or session with `admin` role.
 
 ### Path Parameters
 
@@ -288,7 +288,7 @@ curl -X POST http://localhost:4000/api/v1/agents/550e8400-e29b-41d4-a716-4466554
 
 Permanently revoke an agent. Revoked agents cannot be reactivated.
 
-**Auth:** API key with `admin` scope, or session with `admin` role.
+**Auth:** API key with `agents:lifecycle` scope, or session with `admin` role.
 
 ### Path Parameters
 
@@ -315,7 +315,7 @@ curl -X POST http://localhost:4000/api/v1/agents/550e8400-e29b-41d4-a716-4466554
 
 Reactivate a suspended agent.
 
-**Auth:** API key with `admin` scope, or session with `admin` role.
+**Auth:** API key with `agents:lifecycle` scope, or session with `admin` role.
 
 ### Path Parameters
 
@@ -340,6 +340,6 @@ curl -X POST http://localhost:4000/api/v1/agents/550e8400-e29b-41d4-a716-4466554
 
 | Status | Error | Description |
 |---|---|---|
-| `403` | `forbidden` | Admin role/scope required |
+| `403` | `forbidden` | Required scope (`agents:write` / `agents:lifecycle`) or admin role missing |
 | `404` | `not_found` | Agent does not exist |
 | `409` | `conflict` | Invalid lifecycle transition (e.g., reactivating a revoked agent) |

--- a/apps/docs/content/docs/api-reference/api-keys.mdx
+++ b/apps/docs/content/docs/api-reference/api-keys.mdx
@@ -24,7 +24,7 @@ GET /api/v1/api-keys
       "id": "key_abc123",
       "name": "Production SDK",
       "prefix": "ai_1234",
-      "scopes": ["evaluate", "read"],
+      "scopes": ["evaluate", "traces:read", "traces:write"],
       "last_used_at": "2026-03-23T12:00:00.000Z",
       "created_at": "2026-03-20T10:00:00.000Z",
       "expires_at": null
@@ -48,7 +48,7 @@ POST /api/v1/api-keys
 ```json
 {
   "name": "Production SDK",
-  "scopes": ["evaluate", "read"],
+  "scopes": ["evaluate", "traces:read", "traces:write"],
   "expires_at": "2027-03-23T00:00:00.000Z"
 }
 ```
@@ -56,7 +56,7 @@ POST /api/v1/api-keys
 | Field | Type | Required | Description |
 |-------|------|----------|-------------|
 | `name` | `string` | Yes | Human-readable name |
-| `scopes` | `string[]` | No | Permission scopes: `evaluate`, `read`, `write`, `admin` |
+| `scopes` | `string[]` | Yes | At least one of: `evaluate`, `agents:read`, `agents:write`, `agents:lifecycle`, `policies:read`, `policies:write`, `traces:read`, `traces:write`, `approvals:read`, `approvals:write`, `admin`. See [Authentication — API Key Scopes](/docs/api-reference/auth#api-key-scopes) |
 | `expires_at` | `string` | No | ISO 8601 expiration date (null for no expiry) |
 
 **Response:**
@@ -68,7 +68,7 @@ POST /api/v1/api-keys
     "name": "Production SDK",
     "key": "ai_full_key_shown_only_once",
     "prefix": "ai_1234",
-    "scopes": ["evaluate", "read"],
+    "scopes": ["evaluate", "traces:read", "traces:write"],
     "created_at": "2026-03-23T10:00:00.000Z"
   }
 }
@@ -150,6 +150,11 @@ client = SidClaw(
 | Scope | Permissions |
 |-------|------------|
 | `evaluate` | Call `POST /api/v1/evaluate` |
-| `read` | Read agents, policies, approvals, traces |
-| `write` | Create/update agents, policies |
+| `agents:read` / `agents:write` | Read / create and edit agents |
+| `agents:lifecycle` | Suspend, revoke, reactivate agents |
+| `policies:read` / `policies:write` | Read / create, edit and delete policies |
+| `traces:read` / `traces:write` | Read traces / record outcomes and telemetry |
+| `approvals:read` / `approvals:write` | Read approvals / approve and deny |
 | `admin` | Full access including key management |
+
+See [Authentication — API Key Scopes](/docs/api-reference/auth#api-key-scopes) for the endpoint-by-endpoint mapping.

--- a/apps/docs/content/docs/api-reference/approvals.mdx
+++ b/apps/docs/content/docs/api-reference/approvals.mdx
@@ -198,7 +198,7 @@ curl http://localhost:4000/api/v1/approvals/770e8400-e29b-41d4-a716-446655440002
 
 Approve a pending approval request. This updates the trace, creates audit events, and allows the agent to proceed.
 
-**Auth:** API key with `admin` scope, or session with `reviewer` or `admin` role.
+**Auth:** API key with `approvals:write` scope, or session with `reviewer` or `admin` role.
 
 ### Path Parameters
 
@@ -243,7 +243,7 @@ curl -X POST http://localhost:4000/api/v1/approvals/770e8400-e29b-41d4-a716-4466
 | Status | Error | Description |
 |---|---|---|
 | `400` | `validation_error` | Missing `approver_name` |
-| `403` | `forbidden` | Reviewer or admin role/scope required |
+| `403` | `forbidden` | Required scope (`approvals:write`) or reviewer/admin role missing |
 | `404` | `not_found` | Approval request does not exist |
 | `409` | `conflict` | Approval is not in `pending` status |
 
@@ -253,7 +253,7 @@ curl -X POST http://localhost:4000/api/v1/approvals/770e8400-e29b-41d4-a716-4466
 
 Deny a pending approval request. The agent operation is blocked.
 
-**Auth:** API key with `admin` scope, or session with `reviewer` or `admin` role.
+**Auth:** API key with `approvals:write` scope, or session with `reviewer` or `admin` role.
 
 ### Path Parameters
 
@@ -298,7 +298,7 @@ curl -X POST http://localhost:4000/api/v1/approvals/770e8400-e29b-41d4-a716-4466
 | Status | Error | Description |
 |---|---|---|
 | `400` | `validation_error` | Missing `approver_name` |
-| `403` | `forbidden` | Reviewer or admin role/scope required |
+| `403` | `forbidden` | Required scope (`approvals:write`) or reviewer/admin role missing |
 | `404` | `not_found` | Approval request does not exist |
 | `409` | `conflict` | Approval is not in `pending` status |
 

--- a/apps/docs/content/docs/api-reference/auth.mdx
+++ b/apps/docs/content/docs/api-reference/auth.mdx
@@ -163,11 +163,16 @@ Scopes control which API endpoints a key can access. The `admin` scope grants ac
 | Scope | Endpoints Accessible |
 |---|---|
 | `evaluate` | `POST /evaluate` |
-| `traces:read` | `GET /traces`, `GET /traces/:id`, `GET /traces/export` |
-| `traces:write` | `POST /traces/:traceId/outcome` |
 | `agents:read` | `GET /agents`, `GET /agents/:id` |
+| `agents:write` | `POST /agents`, `PATCH /agents/:id` |
+| `agents:lifecycle` | `POST /agents/:id/suspend`, `POST /agents/:id/revoke`, `POST /agents/:id/reactivate` |
+| `policies:read` | `GET /policies`, `GET /policies/:id`, `GET /policies/:id/versions`, `POST /policies/test` |
+| `policies:write` | `POST /policies`, `PATCH /policies/:id`, `DELETE /policies/:id` |
+| `traces:read` | `GET /traces`, `GET /traces/:id`, `GET /traces/:id/verify`, `GET /traces/export` |
+| `traces:write` | `POST /traces/:traceId/outcome`, `PATCH /traces/:traceId/telemetry` |
 | `approvals:read` | `GET /approvals`, `GET /approvals/:id`, `GET /approvals/:id/status`, `GET /approvals/count` |
-| `admin` | All endpoints (including webhook management, API key management, agent CRUD, policy CRUD, approval decisions) |
+| `approvals:write` | `POST /approvals/:id/approve`, `POST /approvals/:id/deny` |
+| `admin` | All endpoints (including webhook management, API key management, users, billing) |
 
 ### Scope Resolution
 

--- a/apps/docs/content/docs/api-reference/policies.mdx
+++ b/apps/docs/content/docs/api-reference/policies.mdx
@@ -25,7 +25,7 @@ Policy rules define what agents are allowed to do, what requires human approval,
 
 Create a new policy rule.
 
-**Auth:** API key with `admin` scope, or session with `admin` role.
+**Auth:** API key with `policies:write` scope, or session with `admin` role.
 
 ### Request Body
 
@@ -103,7 +103,7 @@ curl -X POST http://localhost:4000/api/v1/policies \
 |---|---|---|
 | `400` | `validation_error` | Invalid or missing fields |
 | `401` | `unauthorized` | Authentication required |
-| `403` | `forbidden` | Admin role/scope required |
+| `403` | `forbidden` | Required scope (`policies:write`) or admin role missing |
 
 ---
 
@@ -111,7 +111,7 @@ curl -X POST http://localhost:4000/api/v1/policies \
 
 List policy rules with optional filters and pagination.
 
-**Auth:** API key with any scope, or any authenticated session.
+**Auth:** API key with `policies:read` scope, or any authenticated session.
 
 ### Query Parameters
 
@@ -162,7 +162,7 @@ curl "http://localhost:4000/api/v1/policies?agent_id=550e8400-...&effect=approva
 
 Get a single policy rule with full detail.
 
-**Auth:** API key with any scope, or any authenticated session.
+**Auth:** API key with `policies:read` scope, or any authenticated session.
 
 ### Path Parameters
 
@@ -211,7 +211,7 @@ Get a single policy rule with full detail.
 
 Update a policy rule. At least one field must be provided. Each update automatically increments the policy version and creates a version history entry.
 
-**Auth:** API key with `admin` scope, or session with `admin` role.
+**Auth:** API key with `policies:write` scope, or session with `admin` role.
 
 ### Path Parameters
 
@@ -267,7 +267,7 @@ curl -X PATCH http://localhost:4000/api/v1/policies/660e8400-e29b-41d4-a716-4466
 | Status | Error | Description |
 |---|---|---|
 | `400` | `validation_error` | No fields provided, or invalid field values |
-| `403` | `forbidden` | Admin role/scope required |
+| `403` | `forbidden` | Required scope (`policies:write`) or admin role missing |
 | `404` | `not_found` | Policy rule does not exist |
 
 ---
@@ -276,7 +276,7 @@ curl -X PATCH http://localhost:4000/api/v1/policies/660e8400-e29b-41d4-a716-4466
 
 Soft-delete (deactivate) a policy rule. The rule remains in the database for audit purposes but is no longer evaluated by the policy engine.
 
-**Auth:** API key with `admin` scope, or session with `admin` role.
+**Auth:** API key with `policies:write` scope, or session with `admin` role.
 
 ### Path Parameters
 
@@ -311,7 +311,7 @@ curl -X DELETE http://localhost:4000/api/v1/policies/660e8400-e29b-41d4-a716-446
 
 | Status | Error | Description |
 |---|---|---|
-| `403` | `forbidden` | Admin role/scope required |
+| `403` | `forbidden` | Required scope (`policies:write`) or admin role missing |
 | `404` | `not_found` | Policy rule does not exist |
 
 ---
@@ -320,7 +320,7 @@ curl -X DELETE http://localhost:4000/api/v1/policies/660e8400-e29b-41d4-a716-446
 
 Get the version history of a policy rule. Each update creates a new version snapshot.
 
-**Auth:** API key with any scope, or any authenticated session.
+**Auth:** API key with `policies:read` scope, or any authenticated session.
 
 ### Path Parameters
 
@@ -382,7 +382,7 @@ curl "http://localhost:4000/api/v1/policies/660e8400-.../versions?limit=10" \
 
 Dry-run a policy evaluation without creating an audit trace. Useful for testing policy configurations before deploying them.
 
-**Auth:** API key with any scope, or any authenticated session.
+**Auth:** API key with `policies:read` scope, or any authenticated session.
 
 ### Request Body
 

--- a/apps/docs/content/docs/api-reference/traces.mdx
+++ b/apps/docs/content/docs/api-reference/traces.mdx
@@ -307,7 +307,7 @@ curl http://localhost:4000/api/v1/traces/550e8400-e29b-41d4-a716-446655440000/ve
 
 Export a single trace as a JSON file with full event and approval data.
 
-**Auth:** API key with `admin` scope, or session with `reviewer` or `admin` role.
+**Auth:** API key with `traces:read` scope, or session with `reviewer` or `admin` role.
 
 ### Path Parameters
 
@@ -366,7 +366,7 @@ curl http://localhost:4000/api/v1/traces/550e8400-e29b-41d4-a716-446655440000/ex
 
 | Status | Error | Description |
 |---|---|---|
-| `403` | `forbidden` | Reviewer or admin role/scope required |
+| `403` | `forbidden` | Required scope (`traces:read`/`traces:write`) or reviewer/admin role missing |
 | `404` | `not_found` | Trace does not exist |
 
 ---
@@ -418,7 +418,7 @@ curl "http://localhost:4000/api/v1/traces/export?from=2026-03-01T00:00:00Z&to=20
 | Status | Error | Description |
 |---|---|---|
 | `400` | `validation_error` | Missing `from`/`to` params, invalid date format, or unsupported format |
-| `403` | `forbidden` | Reviewer or admin role/scope required |
+| `403` | `forbidden` | Required scope (`traces:read`/`traces:write`) or reviewer/admin role missing |
 | `413` | `export_too_large` | Export exceeds 100,000 traces -- narrow the date range |
 
 ---
@@ -493,5 +493,5 @@ curl "http://localhost:4000/api/v1/audit/export?from=2026-03-21T00:00:00Z&to=202
 | Status | Error | Description |
 |---|---|---|
 | `400` | `validation_error` | Missing `from`/`to` params, invalid date format, or unsupported format |
-| `403` | `forbidden` | Reviewer or admin role/scope required |
+| `403` | `forbidden` | Required scope (`traces:read`/`traces:write`) or reviewer/admin role missing |
 | `413` | `export_too_large` | Export exceeds 100,000 events -- narrow the date range |

--- a/apps/docs/content/docs/enterprise/api-keys.mdx
+++ b/apps/docs/content/docs/enterprise/api-keys.mdx
@@ -26,15 +26,25 @@ Each API key is granted one or more scopes that control which API operations it 
 | Scope | Permits |
 |---|---|
 | `evaluate` | `POST /api/v1/evaluate` — evaluate agent actions against policies |
-| `traces:read` | `GET /api/v1/traces` — list and view audit traces |
-| `traces:write` | `POST /api/v1/traces/:id/outcome` — record execution outcomes |
-| `agents:read` | `GET /api/v1/agents` — list and view registered agents |
-| `approvals:read` | `GET /api/v1/approvals` — list and view approval requests |
+| `agents:read` | List and view registered agents |
+| `agents:write` | Register new agents and edit their metadata |
+| `agents:lifecycle` | Suspend, revoke, and reactivate agents. Separate from `agents:write` on purpose: revoke is the kill switch, and reactivate undoes it — a key that can create agents should not be able to un-revoke one |
+| `policies:read` | List and view policy rules and their version history |
+| `policies:write` | Create, edit, and delete policy rules — this can change what any agent is allowed to do |
+| `traces:read` | List, view, verify, and export audit traces |
+| `traces:write` | Record execution outcomes and telemetry against a trace |
+| `approvals:read` | List and view approval requests |
+| `approvals:write` | Approve or deny requests — required by the SidClaw CLI and any custom approver |
 | `admin` | All operations, including key management and webhook configuration |
 
-For SDK clients that only need to evaluate actions and report outcomes, grant `evaluate` and `traces:write`. Add `traces:read` and `approvals:read` only if the client needs to query historical data.
+The dashboard offers presets for the common combinations:
 
-The `admin` scope should only be used for management scripts and CI/CD pipelines that need full access.
+- **Agent runtime** (`evaluate`, `traces:read`, `traces:write`, `approvals:read`, `policies:read`) — what a governed agent process needs at run time; cannot change any governance rule. This is also the scope set of the key auto-created at signup.
+- **Approval client** (`approvals:read`, `approvals:write`) — for the SidClaw CLI or a custom approver.
+- **Project setup** (`agents:write`, `policies:write`, `policies:read`, `agents:read`) — for `create-sidclaw-app --setup-key` and seed scripts; set an expiry and delete when done.
+- **Read only** (`agents:read`, `policies:read`, `traces:read`, `approvals:read`) — observability and reporting.
+
+The `admin` scope should only be used for management scripts and CI/CD pipelines that need full access. Never use it for agent runtime keys.
 
 ## Creating a Key
 

--- a/packages/create-sidclaw-app/src/api-setup.ts
+++ b/packages/create-sidclaw-app/src/api-setup.ts
@@ -47,6 +47,16 @@ export async function setupSidclawResources(
   });
 
   if (!agentRes.ok) {
+    if (agentRes.status === 403) {
+      // The key auto-created at signup is runtime-only by design (it lands in
+      // the generated .env, so it must not be able to create agents/policies).
+      throw new Error(
+        'This API key lacks the agents:write scope (403). The key created at signup ' +
+        'is runtime-only by design. In Settings → API Keys, create a key with the ' +
+        '"Project setup" preset and pass it via --setup-key (it is used once for ' +
+        'setup and never written to the project).'
+      );
+    }
     const body = await agentRes.text().catch(() => '');
     throw new Error(`Failed to create agent: ${agentRes.status} ${body}`);
   }

--- a/packages/create-sidclaw-app/src/index.ts
+++ b/packages/create-sidclaw-app/src/index.ts
@@ -21,12 +21,14 @@ function parseFlags(args: string[]): {
   positional: string | undefined;
   framework: string | undefined;
   apiKey: string | undefined;
+  setupKey: string | undefined;
   apiUrl: string;
   help: boolean;
 } {
   let positional: string | undefined;
   let framework: string | undefined;
   let apiKey: string | undefined;
+  let setupKey: string | undefined;
   let apiUrl = 'https://api.sidclaw.com';
   let help = false;
 
@@ -38,12 +40,16 @@ function parseFlags(args: string[]): {
       framework = args[++i]!;
     } else if ((arg === '--api-key' || arg === '-k') && i + 1 < args.length) {
       apiKey = args[++i]!;
+    } else if (arg === '--setup-key' && i + 1 < args.length) {
+      setupKey = args[++i]!;
     } else if (arg === '--api-url' && i + 1 < args.length) {
       apiUrl = args[++i]!;
     } else if (arg?.startsWith('--framework=')) {
       framework = arg.slice('--framework='.length);
     } else if (arg?.startsWith('--api-key=')) {
       apiKey = arg.slice('--api-key='.length);
+    } else if (arg?.startsWith('--setup-key=')) {
+      setupKey = arg.slice('--setup-key='.length);
     } else if (arg?.startsWith('--api-url=')) {
       apiUrl = arg.slice('--api-url='.length);
     } else if (arg && !arg.startsWith('-') && !positional) {
@@ -51,7 +57,7 @@ function parseFlags(args: string[]): {
     }
   }
 
-  return { positional, framework, apiKey, apiUrl, help };
+  return { positional, framework, apiKey, setupKey, apiUrl, help };
 }
 
 function printHelp() {
@@ -63,7 +69,11 @@ function printHelp() {
 
   Options:
     -f, --framework <name>   Framework template (skip interactive prompt)
-    -k, --api-key <key>      SidClaw API key (starts with ai_)
+    -k, --api-key <key>      Runtime API key, written into the project's .env
+                             (the key auto-created at signup works here)
+        --setup-key <key>    Key with agents:write + policies:write, used ONCE
+                             to create the demo agent + policies, never saved.
+                             Without it, setup is attempted with --api-key.
         --api-url <url>      API URL (default: https://api.sidclaw.com)
     -h, --help               Show this help message
 
@@ -128,11 +138,13 @@ async function main() {
     });
     console.log('Project scaffolded');
 
-    // Set up SidClaw resources if API key provided
-    if (flags.apiKey) {
+    // Set up SidClaw resources if a key was provided. Prefer --setup-key
+    // (write scopes, used once, never persisted); fall back to the runtime key.
+    const provisioningKey = flags.setupKey ?? flags.apiKey;
+    if (provisioningKey) {
       console.log('Setting up agent and policies...');
       try {
-        const { agentId, failedPolicies } = await setupSidclawResources(flags.apiKey, flags.apiUrl, flags.positional);
+        const { agentId, failedPolicies } = await setupSidclawResources(provisioningKey, flags.apiUrl, flags.positional);
         const envPath = resolve(projectDir, '.env');
         const envContent = readFileSync(envPath, 'utf-8');
         writeFileSync(envPath, envContent.replace('your_agent_id_here', agentId));
@@ -265,11 +277,12 @@ async function main() {
   });
   s.stop('Project created');
 
-  // Set up SidClaw resources (agent + policies)
+  // Set up SidClaw resources (agent + policies). Prefer --setup-key (write
+  // scopes, used once, never persisted); fall back to the runtime key.
   let agentSetupName: string | undefined;
   s.start('Setting up agent and policies in SidClaw...');
   try {
-    const { agentId, failedPolicies } = await setupSidclawResources(apiKey as string, apiUrl as string, name as string);
+    const { agentId, failedPolicies } = await setupSidclawResources(flags.setupKey ?? (apiKey as string), apiUrl as string, name as string);
     agentSetupName = `${name as string} Agent`;
     // Replace agent ID placeholder in .env
     const envPath = resolve(projectDir, '.env');


### PR DESCRIPTION
Closes the three items deferred from the #65 scope-model review.

**1. `ApiKey.scopes` DB default `'["*"]'` → `'[]'`** (schema + forward migration `20260728120000`). Every current creation path passes scopes explicitly (route Zod requires `.min(1)`, signup provisioning passes `DEFAULT_SIGNUP_KEY_SCOPES`), so the column default is only ever reached by a future code path that forgets — which previously minted an all-powerful key and now mints a powerless one. Existing rows deliberately untouched: legacy `'*'` keys are handled explicitly in `checkScope`, and rewriting live credentials is a separate operational decision.

**2. `create-sidclaw-app --setup-key`.** The runtime key (`--api-key`) is written into the generated project's `.env` and is runtime-only by design — it cannot create agents or policies. Provisioning now prefers a separate `--setup-key` (write scopes, used once, never persisted), falling back to the runtime key. The 403 error now explains the situation and points at the dashboard's existing **Project setup** preset instead of failing cryptically.

**3. Docs scope vocabulary.** 7 docs pages still described the pre-#65 world. Now:
- `enterprise/api-keys` + `api-reference/auth`: full 11-scope tables (verified line-by-line against `ROUTE_SCOPES`), plus the 4 dashboard presets
- `api-reference/api-keys`: no longer documents `read`/`write` scopes that the Zod enum rejects with 400
- `api-reference/{agents,policies,approvals,traces}`: every **Auth:** line names the scope the route map actually enforces (e.g. approve/deny is `approvals:write`, not `admin`; lifecycle endpoints are `agents:lifecycle`)

**Verification:** `prisma validate` passes; docs production build passes (79/79 pages); create-sidclaw-app builds and `--help` renders the new flag; API typecheck passes. Migration runs against a fresh DB in `test-api` and `api-container-boots`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)