### PR TITLE
fix(shared): exclude test files from the build graph

### DIFF
--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -22,7 +22,7 @@
   "sideEffects": false,
   "scripts": {
     "build": "tsc --build",
-    "typecheck": "tsc --noEmit",
+    "typecheck": "tsc --noEmit -p tsconfig.typecheck.json",
     "lint": "echo 'no linter configured yet'",
     "test": "vitest run"
   },

--- a/packages/shared/tsconfig.json
+++ b/packages/shared/tsconfig.json
@@ -4,5 +4,12 @@
     "outDir": "./dist",
     "rootDir": "./src"
   },
-  "include": ["src"]
+  "include": ["src"],
+  // Test files must not be part of the build graph: the production Dockerfiles
+  // compile this package with `tsc --build` (directly and via project
+  // references from apps/api), and a test file importing vitest makes every
+  // image build depend on devDependency hoisting — which broke all seven
+  // images when vitest 4.1.10 moved (PR #74). Tests are typechecked by the
+  // `typecheck` script via tsconfig.typecheck.json instead.
+  "exclude": ["src/**/__tests__/**", "src/**/*.test.ts"]
 }

--- a/packages/shared/tsconfig.typecheck.json
+++ b/packages/shared/tsconfig.typecheck.json
@@ -1,0 +1,11 @@
+{
+  // Typecheck-only view of the package INCLUDING test files, which are
+  // deliberately excluded from tsconfig.json (see the note there). Used by
+  // the `typecheck` script; never used for emit.
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src"
+  },
+  "include": ["src"]
+}


### PR DESCRIPTION
Dependabot #74 (dev-deps group) broke all seven Docker image builds while source CI stayed green: `packages/shared`'s `tsc --build` compiles `src/schemas/__tests__/schemas.test.ts`, whose `vitest` import resolved only through devDependency hoisting — and vitest 4.1.10 moved. Same failure class as the 2026-07-28 outage; this time the `docker-images` / `api-container-boots` guards caught it pre-merge, which is exactly what they were built for.

**Fix:** exclude `__tests__`/`*.test.ts` from `tsconfig.json` (the config every build path uses, including the apps/api project reference). Tests remain typechecked — the `typecheck` script now runs `tsc --noEmit -p tsconfig.typecheck.json`, which includes them. `dist/test-utils` (exported factory helpers, no vitest import) is unaffected.

**Verified locally:** clean rebuild produces no test artifacts in `dist/`; `typecheck` still covers the test file; vitest suite passes.

Unblocks #74.

🤖 Generated with [Claude Code](https://claude.com/claude-code)