### PR TITLE
fix(api): declare dotenv as a real dependency

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -27,6 +27,7 @@
     "@sidclaw/shared": "*",
     "bcrypt": "^6.0.0",
     "cookie": "^1.1.1",
+    "dotenv": "^16.6.1",
     "fastify": "^5",
     "fastify-plugin": "^5.1.0",
     "openid-client": "^6.8.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -32,6 +32,7 @@
         "@sidclaw/shared": "*",
         "bcrypt": "^6.0.0",
         "cookie": "^1.1.1",
+        "dotenv": "^16.6.1",
         "fastify": "^5",
         "fastify-plugin": "^5.1.0",
         "openid-client": "^6.8.4",


### PR DESCRIPTION
Dependabot #74's prisma 7.5→7.9 bump exposed that `dotenv` — imported at runtime by **both** `apps/api/src/server.ts` and `prisma.config.ts` — was never declared in apps/api's dependencies. It resolved through prisma's transitive tree, so the bump killed the API container at boot (`Cannot find module 'dotenv/config'`). `api-container-boots` caught it pre-merge, again.

This is the **third** undeclared-dependency-masked-by-hoisting in two days (@modelcontextprotocol/sdk → demo builds, vitest → all image builds, now dotenv → API boot). Fix: `"dotenv": "^16.6.1"` in apps/api dependencies.

Unblocks #74 (final blocker, after the shared build fix in #76 cleared the first one).

🤖 Generated with [Claude Code](https://claude.com/claude-code)