### PR TITLE
feat: migrate demo-atlas + vercel-ai example to AI SDK v7

### DIFF
--- a/apps/demo/package.json
+++ b/apps/demo/package.json
@@ -12,17 +12,18 @@
     "test": "echo 'no tests yet'"
   },
   "dependencies": {
-    "@ai-sdk/anthropic": "^1.2.0",
+    "@ai-sdk/anthropic": "^4.0.23",
+    "@ai-sdk/react": "^4.0.44",
     "@sidclaw/sdk": "*",
     "@sidclaw/shared": "*",
-    "ai": "^4.3.0",
+    "ai": "^7.0.41",
     "lucide-react": "^1.27.0",
     "next": "15.5.20",
     "react": "19.2.8",
     "react-dom": "19.2.8",
     "react-markdown": "^10.1.0",
     "sonner": "^2.0.7",
-    "zod": "^3.25.67"
+    "zod": "^4.3.6"
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3.3.6",

--- a/apps/demo/src/app/api/chat/route.ts
+++ b/apps/demo/src/app/api/chat/route.ts
@@ -1,4 +1,4 @@
-import { streamText } from 'ai';
+import { streamText, convertToModelMessages, stepCountIs, type UIMessage } from 'ai';
 import { anthropic } from '@ai-sdk/anthropic';
 import { AgentIdentityClient } from '@sidclaw/sdk';
 import { getOrCreateDemoSession } from '@/lib/demo-session';
@@ -34,7 +34,7 @@ export async function POST(request: Request) {
   const tools = {
     search_knowledge_base: {
       description: 'Search the Atlas Financial internal knowledge base for policy documents, FAQs, and guides. Use this for general questions about refunds, transfers, fees, security.',
-      parameters: z.object({
+      inputSchema: z.object({
         query: z.string().describe('The search query'),
       }),
       execute: async ({ query }: { query: string }) => {
@@ -61,7 +61,7 @@ export async function POST(request: Request) {
 
     lookup_account: {
       description: 'Look up a customer account by account ID. Returns account details including name, balance, type, and support tier.',
-      parameters: z.object({
+      inputSchema: z.object({
         account_id: z.string().describe('The account ID (e.g., A-1234)'),
       }),
       execute: async ({ account_id }: { account_id: string }) => {
@@ -88,7 +88,7 @@ export async function POST(request: Request) {
 
     send_email: {
       description: 'Send an email to a customer. Use this for follow-ups, notifications, or responses. Requires human approval before sending.',
-      parameters: z.object({
+      inputSchema: z.object({
         to: z.string().describe('Customer email address'),
         subject: z.string().describe('Email subject line'),
         body: z.string().describe('Email body content'),
@@ -117,7 +117,7 @@ export async function POST(request: Request) {
 
     update_case: {
       description: 'Update a support case with new notes or status changes. Requires human approval for modifications.',
-      parameters: z.object({
+      inputSchema: z.object({
         case_id: z.string().describe('The case ID (e.g., C-5678)'),
         notes: z.string().describe('Notes to add to the case'),
       }),
@@ -145,7 +145,7 @@ export async function POST(request: Request) {
 
     export_customer_data: {
       description: 'Export customer data to a file. This is typically blocked by policy.',
-      parameters: z.object({
+      inputSchema: z.object({
         format: z.string().describe('Export format (csv, json)'),
         scope: z.string().describe('What data to export'),
       }),
@@ -169,7 +169,7 @@ export async function POST(request: Request) {
 
     close_account: {
       description: 'Close a customer account. This is a high-risk action typically blocked by policy.',
-      parameters: z.object({
+      inputSchema: z.object({
         account_id: z.string().describe('The account ID to close'),
         reason: z.string().describe('Reason for closure'),
       }),
@@ -214,10 +214,10 @@ CRITICAL RULES:
 - For case references, use C-5678 as the default.
 
 You are demonstrating SidClaw's governance platform. The governance decisions you encounter (allow, approval_required, deny) are being made in real-time by the SidClaw policy engine based on actual policy rules configured for Atlas Financial. It is essential that every action goes through the tools so the governance trace appears on the right panel.`,
-    messages,
+    messages: await convertToModelMessages(messages as UIMessage[]),
     tools,
-    maxSteps: 5,
+    stopWhen: stepCountIs(5),
   });
 
-  return result.toDataStreamResponse();
+  return result.toUIMessageStreamResponse();
 }

--- a/apps/demo/src/components/ChatInterface.tsx
+++ b/apps/demo/src/components/ChatInterface.tsx
@@ -1,11 +1,20 @@
 'use client';
 
-import { useChat } from 'ai/react';
+import { useChat } from '@ai-sdk/react';
+import { DefaultChatTransport, type UIMessage } from 'ai';
 import { ChatMessage } from './ChatMessage';
 import { ChatInput } from './ChatInput';
 import { SuggestedPrompts } from './SuggestedPrompts';
-import { useRef, useEffect } from 'react';
+import { useRef, useEffect, useMemo, useState } from 'react';
 import type { ApprovalNotification } from '@/app/page';
+
+/** Concatenate the text parts of a UIMessage (AI SDK v5+ message shape). */
+function messageText(message: UIMessage): string {
+  return message.parts
+    .filter((part): part is Extract<typeof part, { type: 'text' }> => part.type === 'text')
+    .map((part) => part.text)
+    .join('');
+}
 
 interface ChatInterfaceProps {
   sessionId: string;
@@ -22,10 +31,23 @@ const OP_LABELS: Record<string, string> = {
 };
 
 export function ChatInterface({ sessionId, agentId, apiKey, notifications = [] }: ChatInterfaceProps) {
-  const { messages, input, handleInputChange, handleSubmit, isLoading, append } = useChat({
-    api: '/api/chat',
-    body: { sessionId, agentId, apiKey },
-  });
+  // v5+ useChat no longer manages input state or accepts api/body directly —
+  // extra request fields travel via the transport, input state is ours.
+  const transport = useMemo(
+    () => new DefaultChatTransport({ api: '/api/chat', body: { sessionId, agentId, apiKey } }),
+    [sessionId, agentId, apiKey],
+  );
+  const { messages, sendMessage, status } = useChat({ transport });
+  const [input, setInput] = useState('');
+  const isLoading = status === 'submitted' || status === 'streaming';
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    const text = input.trim();
+    if (!text || isLoading) return;
+    sendMessage({ text });
+    setInput('');
+  };
 
   const messagesEndRef = useRef<HTMLDivElement>(null);
 
@@ -34,7 +56,7 @@ export function ChatInterface({ sessionId, agentId, apiKey, notifications = [] }
   }, [messages, notifications]);
 
   const handleSuggestedPrompt = (prompt: string) => {
-    append({ role: 'user', content: prompt });
+    sendMessage({ text: prompt });
   };
 
   return (
@@ -57,7 +79,7 @@ export function ChatInterface({ sessionId, agentId, apiKey, notifications = [] }
           </div>
         )}
         {messages.map((message) => (
-          <ChatMessage key={message.id} message={message} />
+          <ChatMessage key={message.id} message={{ role: message.role, content: messageText(message) }} />
         ))}
         {isLoading && (
           <div className="flex items-center gap-2 text-base text-[#71717A]">
@@ -108,7 +130,7 @@ export function ChatInterface({ sessionId, agentId, apiKey, notifications = [] }
       {/* Input */}
       <ChatInput
         input={input}
-        onChange={handleInputChange}
+        onChange={(e) => setInput(e.target.value)}
         onSubmit={handleSubmit}
         isLoading={isLoading}
       />

--- a/examples/vercel-ai-assistant/app/api/chat/route.ts
+++ b/examples/vercel-ai-assistant/app/api/chat/route.ts
@@ -1,4 +1,4 @@
-import { streamText } from 'ai';
+import { streamText, convertToModelMessages, stepCountIs, type UIMessage } from 'ai';
 import { openai } from '@ai-sdk/openai';
 import { z } from 'zod';
 import { AgentIdentityClient } from '@sidclaw/sdk';
@@ -17,7 +17,7 @@ const client = new AgentIdentityClient({
 const tools = {
   check_inventory: {
     description: 'Check product inventory levels',
-    parameters: z.object({
+    inputSchema: z.object({
       product: z.string().describe('Product name to check'),
     }),
     execute: async ({ product }: { product: string }) => {
@@ -35,7 +35,7 @@ const tools = {
   },
   send_notification: {
     description: 'Send a notification email to a customer',
-    parameters: z.object({
+    inputSchema: z.object({
       to: z.string().describe('Recipient email address'),
       message: z.string().describe('Notification message'),
     }),
@@ -46,7 +46,7 @@ const tools = {
   },
   delete_records: {
     description: 'Delete all records for a customer (destructive operation)',
-    parameters: z.object({
+    inputSchema: z.object({
       customerId: z.string().describe('Customer ID whose records to delete'),
     }),
     execute: async ({ customerId }: { customerId: string }) => {
@@ -70,10 +70,10 @@ export async function POST(req: Request) {
     system: `You are a helpful assistant with access to governed tools.
 Some tools may be blocked by governance policies — if a tool call fails with a policy denial,
 explain to the user that the action was blocked and why. Be concise.`,
-    messages,
+    messages: await convertToModelMessages(messages as UIMessage[]),
     tools: governedTools,
-    maxSteps: 3,
+    stopWhen: stepCountIs(3),
   });
 
-  return result.toDataStreamResponse();
+  return result.toUIMessageStreamResponse();
 }

--- a/examples/vercel-ai-assistant/app/page.tsx
+++ b/examples/vercel-ai-assistant/app/page.tsx
@@ -1,11 +1,19 @@
 'use client';
 
-import { useChat } from 'ai/react';
+import { useChat } from '@ai-sdk/react';
+import { useState } from 'react';
 
 export default function ChatPage() {
-  const { messages, input, handleInputChange, handleSubmit, isLoading } = useChat({
-    api: '/api/chat',
-  });
+  const { messages, sendMessage, status } = useChat();
+  const [input, setInput] = useState('');
+  const isLoading = status === 'submitted' || status === 'streaming';
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    const text = input.trim();
+    if (!text || isLoading) return;
+    sendMessage({ text });
+    setInput('');
+  };
 
   return (
     <div className="mx-auto flex h-screen max-w-2xl flex-col p-4">
@@ -65,19 +73,30 @@ export default function ChatPage() {
                   : 'bg-zinc-900 text-zinc-300 border border-zinc-800'
               }`}
             >
-              <pre className="whitespace-pre-wrap font-sans">{message.content}</pre>
-              {message.toolInvocations?.map((invocation, i) => (
-                <div key={i} className="mt-2 rounded border border-zinc-700 bg-zinc-950 p-2 text-xs">
-                  <span className="font-mono text-zinc-500">tool: {invocation.toolName}</span>
-                  {'result' in invocation && (
-                    <pre className="mt-1 text-zinc-400 whitespace-pre-wrap">
-                      {typeof invocation.result === 'string'
-                        ? invocation.result
-                        : JSON.stringify(invocation.result, null, 2)}
-                    </pre>
-                  )}
-                </div>
-              ))}
+              {message.parts.map((part, i) => {
+                if (part.type === 'text') {
+                  return (
+                    <pre key={i} className="whitespace-pre-wrap font-sans">{part.text}</pre>
+                  );
+                }
+                if (part.type.startsWith('tool-') || part.type === 'dynamic-tool') {
+                  const toolName = part.type === 'dynamic-tool'
+                    ? (part as { toolName: string }).toolName
+                    : part.type.slice('tool-'.length);
+                  const output = (part as { output?: unknown }).output;
+                  return (
+                    <div key={i} className="mt-2 rounded border border-zinc-700 bg-zinc-950 p-2 text-xs">
+                      <span className="font-mono text-zinc-500">tool: {toolName}</span>
+                      {output !== undefined && (
+                        <pre className="mt-1 text-zinc-400 whitespace-pre-wrap">
+                          {typeof output === 'string' ? output : JSON.stringify(output, null, 2)}
+                        </pre>
+                      )}
+                    </div>
+                  );
+                }
+                return null;
+              })}
             </div>
           </div>
         ))}
@@ -95,7 +114,7 @@ export default function ChatPage() {
       <form onSubmit={handleSubmit} className="flex gap-2 border-t border-zinc-800 pt-4">
         <input
           value={input}
-          onChange={handleInputChange}
+          onChange={(e) => setInput(e.target.value)}
           placeholder="Ask something..."
           className="flex-1 rounded border border-zinc-700 bg-zinc-900 px-4 py-2 text-sm text-zinc-100 placeholder-zinc-600 outline-none focus:border-zinc-500"
           disabled={isLoading}

--- a/examples/vercel-ai-assistant/package.json
+++ b/examples/vercel-ai-assistant/package.json
@@ -9,20 +9,21 @@
     "start": "next start --port 3001"
   },
   "dependencies": {
+    "@ai-sdk/openai": "^4.0.23",
+    "@ai-sdk/react": "^4.0.44",
     "@sidclaw/sdk": "*",
-    "ai": "^4.0.0",
-    "@ai-sdk/openai": "^1.0.0",
+    "ai": "^7.0.41",
     "next": "^15.0.0",
     "react": "^19.2.8",
     "react-dom": "^19.2.8",
-    "zod": "^3.23.0"
+    "zod": "^4.3.6"
   },
   "devDependencies": {
+    "@tailwindcss/postcss": "^4.3.3",
     "@types/react": "^19.2.17",
     "@types/react-dom": "^19.0.0",
-    "tailwindcss": "^4.0.0",
-    "@tailwindcss/postcss": "^4.3.3",
     "postcss": "^8.5.24",
+    "tailwindcss": "^4.0.0",
     "tsx": "^4.23.1",
     "typescript": "^5.9.0"
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -345,17 +345,18 @@
       "name": "@sidclaw/demo-atlas",
       "version": "0.1.0",
       "dependencies": {
-        "@ai-sdk/anthropic": "^1.2.0",
+        "@ai-sdk/anthropic": "^4.0.23",
+        "@ai-sdk/react": "^4.0.44",
         "@sidclaw/sdk": "*",
         "@sidclaw/shared": "*",
-        "ai": "^4.3.0",
+        "ai": "^7.0.41",
         "lucide-react": "^1.27.0",
         "next": "15.5.20",
         "react": "19.2.8",
         "react-dom": "19.2.8",
         "react-markdown": "^10.1.0",
         "sonner": "^2.0.7",
-        "zod": "^3.25.67"
+        "zod": "^4.3.6"
       },
       "devDependencies": {
         "@eslint/eslintrc": "^3.3.6",
@@ -413,121 +414,6 @@
         "eslint-config-next": "15.5.14",
         "tailwindcss": "^4",
         "typescript": "^5.9.3"
-      }
-    },
-    "apps/demo/node_modules/@ai-sdk/anthropic": {
-      "version": "1.2.12",
-      "resolved": "https://registry.npmjs.org/@ai-sdk/anthropic/-/anthropic-1.2.12.tgz",
-      "integrity": "sha512-YSzjlko7JvuiyQFmI9RN1tNZdEiZxc+6xld/0tq/VkJaHpEzGAb1yiNxxvmYVcjvfu/PcvCxAAYXmTYQQ63IHQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@ai-sdk/provider": "1.1.3",
-        "@ai-sdk/provider-utils": "2.2.8"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "peerDependencies": {
-        "zod": "^3.0.0"
-      }
-    },
-    "apps/demo/node_modules/@ai-sdk/provider-utils": {
-      "version": "2.2.8",
-      "resolved": "https://registry.npmjs.org/@ai-sdk/provider-utils/-/provider-utils-2.2.8.tgz",
-      "integrity": "sha512-fqhG+4sCVv8x7nFzYnFo19ryhAa3w096Kmc3hWxMQfW/TubPOmt3A6tYZhl4mUfQWWQMsuSkLrtjlWuXBVSGQA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@ai-sdk/provider": "1.1.3",
-        "nanoid": "^3.3.8",
-        "secure-json-parse": "^2.7.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "peerDependencies": {
-        "zod": "^3.23.8"
-      }
-    },
-    "apps/demo/node_modules/@ai-sdk/ui-utils": {
-      "version": "1.2.11",
-      "resolved": "https://registry.npmjs.org/@ai-sdk/ui-utils/-/ui-utils-1.2.11.tgz",
-      "integrity": "sha512-3zcwCc8ezzFlwp3ZD15wAPjf2Au4s3vAbKsXQVyhxODHcmu0iyPO2Eua6D/vicq/AUm/BAo60r97O6HU+EI0+w==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@ai-sdk/provider": "1.1.3",
-        "@ai-sdk/provider-utils": "2.2.8",
-        "zod-to-json-schema": "^3.24.1"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "peerDependencies": {
-        "zod": "^3.23.8"
-      }
-    },
-    "apps/demo/node_modules/ai": {
-      "version": "4.3.19",
-      "resolved": "https://registry.npmjs.org/ai/-/ai-4.3.19.tgz",
-      "integrity": "sha512-dIE2bfNpqHN3r6IINp9znguYdhIOheKW2LDigAMrgt/upT3B8eBGPSCblENvaZGoq+hxaN9fSMzjWpbqloP+7Q==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@ai-sdk/provider": "1.1.3",
-        "@ai-sdk/provider-utils": "2.2.8",
-        "@ai-sdk/react": "1.2.12",
-        "@ai-sdk/ui-utils": "1.2.11",
-        "@opentelemetry/api": "1.9.0",
-        "jsondiffpatch": "0.6.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "peerDependencies": {
-        "react": "^18 || ^19 || ^19.0.0-rc",
-        "zod": "^3.23.8"
-      },
-      "peerDependenciesMeta": {
-        "react": {
-          "optional": true
-        }
-      }
-    },
-    "apps/demo/node_modules/ai/node_modules/@ai-sdk/react": {
-      "version": "1.2.12",
-      "resolved": "https://registry.npmjs.org/@ai-sdk/react/-/react-1.2.12.tgz",
-      "integrity": "sha512-jK1IZZ22evPZoQW3vlkZ7wvjYGYF+tRBKXtrcolduIkQ/m/sOAVcVeVDUDvh1T91xCnWCdUGCPZg2avZ90mv3g==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@ai-sdk/provider-utils": "2.2.8",
-        "@ai-sdk/ui-utils": "1.2.11",
-        "swr": "^2.2.5",
-        "throttleit": "2.1.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "peerDependencies": {
-        "react": "^18 || ^19 || ^19.0.0-rc",
-        "zod": "^3.23.8"
-      },
-      "peerDependenciesMeta": {
-        "zod": {
-          "optional": true
-        }
-      }
-    },
-    "apps/demo/node_modules/secure-json-parse": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/secure-json-parse/-/secure-json-parse-2.7.0.tgz",
-      "integrity": "sha512-6aU+Rwsezw7VR8/nyvKTx8QpWH9FrcYiXXlqC4z5d5XQBDRqtbfsRjnwGyqbi3gddNtWHuEk9OANUotL26qKUw==",
-      "license": "BSD-3-Clause"
-    },
-    "apps/demo/node_modules/zod": {
-      "version": "3.25.76",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
-      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/sponsors/colinhacks"
       }
     },
     "apps/docs": {
@@ -683,13 +569,14 @@
     "examples/vercel-ai-assistant": {
       "name": "vercel-ai-assistant-example",
       "dependencies": {
-        "@ai-sdk/openai": "^1.0.0",
+        "@ai-sdk/openai": "^4.0.23",
+        "@ai-sdk/react": "^4.0.44",
         "@sidclaw/sdk": "*",
-        "ai": "^4.0.0",
+        "ai": "^7.0.41",
         "next": "^15.0.0",
         "react": "^19.2.8",
         "react-dom": "^19.2.8",
-        "zod": "^3.23.0"
+        "zod": "^4.3.6"
       },
       "devDependencies": {
         "@tailwindcss/postcss": "^4.3.3",
@@ -701,131 +588,120 @@
         "typescript": "^5.9.0"
       }
     },
-    "examples/vercel-ai-assistant/node_modules/@ai-sdk/openai": {
-      "version": "1.3.24",
-      "resolved": "https://registry.npmjs.org/@ai-sdk/openai/-/openai-1.3.24.tgz",
-      "integrity": "sha512-GYXnGJTHRTZc4gJMSmFRgEQudjqd4PUN0ZjQhPwOAYH1yOAvQoG/Ikqs+HyISRbLPCrhbZnPKCNHuRU4OfpW0Q==",
+    "node_modules/@ai-sdk/anthropic": {
+      "version": "4.0.23",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/anthropic/-/anthropic-4.0.23.tgz",
+      "integrity": "sha512-9sky++sOcQ3V38XWqPpiLIe4knjWREOUEv3ZOZZ9mTQepb2Ho60NUFGR/0NxQlTHEW9G0zxciEecySNE/iHdVQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@ai-sdk/provider": "1.1.3",
-        "@ai-sdk/provider-utils": "2.2.8"
+        "@ai-sdk/provider": "4.0.4",
+        "@ai-sdk/provider-utils": "5.0.14"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=22"
       },
       "peerDependencies": {
-        "zod": "^3.0.0"
+        "zod": "^3.25.76 || ^4.1.8"
       }
     },
-    "examples/vercel-ai-assistant/node_modules/@ai-sdk/provider-utils": {
-      "version": "2.2.8",
-      "resolved": "https://registry.npmjs.org/@ai-sdk/provider-utils/-/provider-utils-2.2.8.tgz",
-      "integrity": "sha512-fqhG+4sCVv8x7nFzYnFo19ryhAa3w096Kmc3hWxMQfW/TubPOmt3A6tYZhl4mUfQWWQMsuSkLrtjlWuXBVSGQA==",
+    "node_modules/@ai-sdk/gateway": {
+      "version": "4.0.31",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/gateway/-/gateway-4.0.31.tgz",
+      "integrity": "sha512-gEBBUP7nyfQY+K+xFllYJ374RbJoRUa5RN2NyLPu12OfMv5U09kNzZTvBDHnqx78P/7qEELyIg9C5k+RPiBkjg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@ai-sdk/provider": "1.1.3",
-        "nanoid": "^3.3.8",
-        "secure-json-parse": "^2.7.0"
+        "@ai-sdk/provider": "4.0.4",
+        "@ai-sdk/provider-utils": "5.0.14",
+        "@vercel/oidc": "3.2.0"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=22"
       },
       "peerDependencies": {
-        "zod": "^3.23.8"
+        "zod": "^3.25.76 || ^4.1.8"
       }
     },
-    "examples/vercel-ai-assistant/node_modules/@ai-sdk/react": {
-      "version": "1.2.12",
-      "resolved": "https://registry.npmjs.org/@ai-sdk/react/-/react-1.2.12.tgz",
-      "integrity": "sha512-jK1IZZ22evPZoQW3vlkZ7wvjYGYF+tRBKXtrcolduIkQ/m/sOAVcVeVDUDvh1T91xCnWCdUGCPZg2avZ90mv3g==",
+    "node_modules/@ai-sdk/mcp": {
+      "version": "2.0.18",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/mcp/-/mcp-2.0.18.tgz",
+      "integrity": "sha512-0NEiqoS3PzkITQFldRuuPyO+CckgUPb9wWkp2hQlcaGxKu9ebFJDyjxGYEySE7TQN7mYc8PUuaNEODvky51NaA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@ai-sdk/provider-utils": "2.2.8",
-        "@ai-sdk/ui-utils": "1.2.11",
-        "swr": "^2.2.5",
-        "throttleit": "2.1.0"
+        "@ai-sdk/provider": "4.0.4",
+        "@ai-sdk/provider-utils": "5.0.14",
+        "pkce-challenge": "^5.0.1"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=22"
       },
       "peerDependencies": {
-        "react": "^18 || ^19 || ^19.0.0-rc",
-        "zod": "^3.23.8"
-      },
-      "peerDependenciesMeta": {
-        "zod": {
-          "optional": true
-        }
+        "zod": "^3.25.76 || ^4.1.8"
       }
     },
-    "examples/vercel-ai-assistant/node_modules/@ai-sdk/ui-utils": {
-      "version": "1.2.11",
-      "resolved": "https://registry.npmjs.org/@ai-sdk/ui-utils/-/ui-utils-1.2.11.tgz",
-      "integrity": "sha512-3zcwCc8ezzFlwp3ZD15wAPjf2Au4s3vAbKsXQVyhxODHcmu0iyPO2Eua6D/vicq/AUm/BAo60r97O6HU+EI0+w==",
+    "node_modules/@ai-sdk/openai": {
+      "version": "4.0.23",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/openai/-/openai-4.0.23.tgz",
+      "integrity": "sha512-J7ad/TxUVpPl+oXHZzvpg9Y7NsrimF26LpF91PLgLbpkfMijv3ze9V4CRP3XYWhHwo6Qda/yy4bHmRDhIa8WrQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@ai-sdk/provider": "1.1.3",
-        "@ai-sdk/provider-utils": "2.2.8",
-        "zod-to-json-schema": "^3.24.1"
+        "@ai-sdk/provider": "4.0.4",
+        "@ai-sdk/provider-utils": "5.0.14"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=22"
       },
       "peerDependencies": {
-        "zod": "^3.23.8"
-      }
-    },
-    "examples/vercel-ai-assistant/node_modules/ai": {
-      "version": "4.3.19",
-      "resolved": "https://registry.npmjs.org/ai/-/ai-4.3.19.tgz",
-      "integrity": "sha512-dIE2bfNpqHN3r6IINp9znguYdhIOheKW2LDigAMrgt/upT3B8eBGPSCblENvaZGoq+hxaN9fSMzjWpbqloP+7Q==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@ai-sdk/provider": "1.1.3",
-        "@ai-sdk/provider-utils": "2.2.8",
-        "@ai-sdk/react": "1.2.12",
-        "@ai-sdk/ui-utils": "1.2.11",
-        "@opentelemetry/api": "1.9.0",
-        "jsondiffpatch": "0.6.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "peerDependencies": {
-        "react": "^18 || ^19 || ^19.0.0-rc",
-        "zod": "^3.23.8"
-      },
-      "peerDependenciesMeta": {
-        "react": {
-          "optional": true
-        }
-      }
-    },
-    "examples/vercel-ai-assistant/node_modules/secure-json-parse": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/secure-json-parse/-/secure-json-parse-2.7.0.tgz",
-      "integrity": "sha512-6aU+Rwsezw7VR8/nyvKTx8QpWH9FrcYiXXlqC4z5d5XQBDRqtbfsRjnwGyqbi3gddNtWHuEk9OANUotL26qKUw==",
-      "license": "BSD-3-Clause"
-    },
-    "examples/vercel-ai-assistant/node_modules/zod": {
-      "version": "3.25.76",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
-      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/sponsors/colinhacks"
+        "zod": "^3.25.76 || ^4.1.8"
       }
     },
     "node_modules/@ai-sdk/provider": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/@ai-sdk/provider/-/provider-1.1.3.tgz",
-      "integrity": "sha512-qZMxYJ0qqX/RfnuIaab+zp8UAeJn/ygXXAffR5I4N0n1IrvA6qBsjc8hXLmBiMV2zoXlifkacF7sEFnYnjBcqg==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/provider/-/provider-4.0.4.tgz",
+      "integrity": "sha512-tbHKNLirllUNF3ZlkCsXnwab2ZV1Sl4b1H/Cp9ruCce15IBmskE8Gwkk0yo9xDWY+jho2of7lVXtwSsyrq7cwQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "json-schema": "^0.4.0"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=22"
+      }
+    },
+    "node_modules/@ai-sdk/provider-utils": {
+      "version": "5.0.14",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/provider-utils/-/provider-utils-5.0.14.tgz",
+      "integrity": "sha512-HW+Ys98cr2BRQzP6jTlp2bRKIqt+oAjYNLm9gqUUQkLz7QERtaPgDZOoXHz9IXSXoOtz175p4Q17qKQdEX0Hag==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/provider": "4.0.4",
+        "@standard-schema/spec": "^1.1.0",
+        "@workflow/serde": "4.1.0",
+        "eventsource-parser": "^3.0.8"
+      },
+      "engines": {
+        "node": ">=22"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.76 || ^4.1.8"
+      }
+    },
+    "node_modules/@ai-sdk/react": {
+      "version": "4.0.44",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/react/-/react-4.0.44.tgz",
+      "integrity": "sha512-n/ouApRYXh//hxAItWg5xdKYGKhVigoWU/sf7uZExPB3uvQcrOKNCcNhF3r0WTdvWHQj+XHVqiRtPj/mMSVh8g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/mcp": "2.0.18",
+        "@ai-sdk/provider": "4.0.4",
+        "@ai-sdk/provider-utils": "5.0.14",
+        "ai": "7.0.41",
+        "swr": "^2.4.1",
+        "throttleit": "2.1.0"
+      },
+      "engines": {
+        "node": ">=22"
+      },
+      "peerDependencies": {
+        "react": "^18 || ~19.0.1 || ~19.1.2 || ^19.2.1"
       }
     },
     "node_modules/@alloc/quick-lru": {
@@ -2890,16 +2766,6 @@
         "zod": "^4.0.0"
       }
     },
-    "node_modules/@openai/agents-openai/node_modules/zod": {
-      "version": "3.25.76",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
-      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
-      "license": "MIT",
-      "peer": true,
-      "funding": {
-        "url": "https://github.com/sponsors/colinhacks"
-      }
-    },
     "node_modules/@openai/agents-realtime": {
       "version": "0.14.0",
       "resolved": "https://registry.npmjs.org/@openai/agents-realtime/-/agents-realtime-0.14.0.tgz",
@@ -2915,31 +2781,13 @@
         "zod": "^4.0.0"
       }
     },
-    "node_modules/@openai/agents-realtime/node_modules/zod": {
-      "version": "3.25.76",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
-      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
-      "license": "MIT",
-      "peer": true,
-      "funding": {
-        "url": "https://github.com/sponsors/colinhacks"
-      }
-    },
-    "node_modules/@openai/agents/node_modules/zod": {
-      "version": "3.25.76",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
-      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
-      "license": "MIT",
-      "peer": true,
-      "funding": {
-        "url": "https://github.com/sponsors/colinhacks"
-      }
-    },
     "node_modules/@opentelemetry/api": {
       "version": "1.9.0",
       "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.0.tgz",
       "integrity": "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==",
       "license": "Apache-2.0",
+      "optional": true,
+      "peer": true,
       "engines": {
         "node": ">=8.0.0"
       }
@@ -5474,12 +5322,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/@types/diff-match-patch": {
-      "version": "1.0.36",
-      "resolved": "https://registry.npmjs.org/@types/diff-match-patch/-/diff-match-patch-1.0.36.tgz",
-      "integrity": "sha512-xFdR6tkm0MWvBfO8xXCSsinYxHcqkQUlcHeSpMC2ukzOb6lwQAfDmW+Qt0AvlGd8HpsS28qKsB+oPeJn9I39jg==",
-      "license": "MIT"
-    },
     "node_modules/@types/estree": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
@@ -6174,6 +6016,15 @@
         "win32"
       ]
     },
+    "node_modules/@vercel/oidc": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@vercel/oidc/-/oidc-3.2.0.tgz",
+      "integrity": "sha512-UycprH3T6n3jH0k44NHMa7pnFHGu/N05MjojYr+Mc6I7obkoLIJujSWwin1pCvdy/eOxrI/l3uDLQsmcrOb4ug==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">= 20"
+      }
+    },
     "node_modules/@visx/curve": {
       "version": "4.0.1-alpha.0",
       "resolved": "https://registry.npmjs.org/@visx/curve/-/curve-4.0.1-alpha.0.tgz",
@@ -6342,6 +6193,12 @@
         "node": ">=12"
       }
     },
+    "node_modules/@workflow/serde": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@workflow/serde/-/serde-4.1.0.tgz",
+      "integrity": "sha512-pav4F2BoirECWR7Nf1TKt+2eETcBj7jj4cBefQ8VXQCA6NPkaKeLfj/zMgi+3zYV5ZIBT4GuUiphsj0/b9hPQQ==",
+      "license": "Apache-2.0"
+    },
     "node_modules/@xyflow/react": {
       "version": "12.11.2",
       "resolved": "https://registry.npmjs.org/@xyflow/react/-/react-12.11.2.tgz",
@@ -6446,6 +6303,23 @@
       },
       "engines": {
         "node": ">= 8.0.0"
+      }
+    },
+    "node_modules/ai": {
+      "version": "7.0.41",
+      "resolved": "https://registry.npmjs.org/ai/-/ai-7.0.41.tgz",
+      "integrity": "sha512-GvV7uet1dz3wZFAnLd8rS+rSwIh57b8YvbV/gPaSxKsJkj1wGVnlWbu9pqKG3Op68/mglkz0lIkpsJXy2rBX1A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/gateway": "4.0.31",
+        "@ai-sdk/provider": "4.0.4",
+        "@ai-sdk/provider-utils": "5.0.14"
+      },
+      "engines": {
+        "node": ">=22"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.76 || ^4.1.8"
       }
     },
     "node_modules/ajv": {
@@ -7944,12 +7818,6 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
-    "node_modules/diff-match-patch": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/diff-match-patch/-/diff-match-patch-1.0.5.tgz",
-      "integrity": "sha512-IayShXAgj/QMXgB0IWmKx+rOPuGMhqm5w6jvFxmVenXKIzRqTAAsbBPT3kWQeGANj3jGgvcvv4yK6SxqYmikgw==",
-      "license": "Apache-2.0"
-    },
     "node_modules/doctrine": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.1.0.tgz",
@@ -8919,9 +8787,9 @@
       }
     },
     "node_modules/eventsource-parser": {
-      "version": "3.0.6",
-      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.0.6.tgz",
-      "integrity": "sha512-Vo1ab+QXPzZ4tCa8SwIHJFaSzy4R6SHf7BY79rFBDf0idraZWAkYrDjDj8uWaSm3S2TK+hJ7/t1CEmZ7jXw+pg==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.1.0.tgz",
+      "integrity": "sha512-kJezFj9YFAMLeORyi7aCLxLbD5/qWMQnoMVlVPyHIll7lgRJCc3JVln9Vgl9nwQi0YkMnhdGTMNn7CkRRAptMg==",
       "license": "MIT",
       "engines": {
         "node": ">=18.0.0"
@@ -11139,35 +11007,6 @@
       },
       "bin": {
         "json5": "lib/cli.js"
-      }
-    },
-    "node_modules/jsondiffpatch": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/jsondiffpatch/-/jsondiffpatch-0.6.0.tgz",
-      "integrity": "sha512-3QItJOXp2AP1uv7waBkao5nCvhEv+QmJAd38Ybq7wNI74Q+BBmnLn4EDKz6yI9xGAIQoUF87qHt+kc1IVxB4zQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/diff-match-patch": "^1.0.36",
-        "chalk": "^5.3.0",
-        "diff-match-patch": "^1.0.5"
-      },
-      "bin": {
-        "jsondiffpatch": "bin/jsondiffpatch.js"
-      },
-      "engines": {
-        "node": "^18.0.0 || >=20.0.0"
-      }
-    },
-    "node_modules/jsondiffpatch/node_modules/chalk": {
-      "version": "5.6.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
-      "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
-      "license": "MIT",
-      "engines": {
-        "node": "^12.17.0 || ^14.13 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
     "node_modules/jsx-ast-utils": {
@@ -17527,9 +17366,9 @@
       }
     },
     "node_modules/zod": {
-      "version": "4.3.6",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
-      "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
+      "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"


### PR DESCRIPTION
Dependabot #28/#31 bumped only the provider packages, which can't work without the matching `ai` core major and the v5+ API surface. This does the real migration for both consumers (apps/demo, examples/vercel-ai-assistant):

- `ai` ^7.0.41 + providers ^4.0.23 + `@ai-sdk/react` ^4.0.44 + zod ^4 (zod 3 against ai v7's zod-4-typed `inputSchema` produces TS2589 type-depth explosions)
- `parameters` → `inputSchema`; `maxSteps` → `stopWhen: stepCountIs(n)`; `toDataStreamResponse` → `toUIMessageStreamResponse`; server receives UIMessages via `await convertToModelMessages`
- Client: `useChat` from `@ai-sdk/react` with `DefaultChatTransport` carrying the demo's custom body (sessionId/agentId/apiKey), local input state, `sendMessage({ text })`, UIMessage `parts` rendering incl. tool outputs

`governVercelTools` in the SDK is untouched — it's structural over `execute()` and works with both tool shapes.

**Verified:** `tsc --noEmit` + `next build` pass for both apps locally; `docker-images (demo-atlas)` in CI covers the image path that failed on #28.

Supersedes #28 and #31 (will close them on merge).

🤖 Generated with [Claude Code](https://claude.com/claude-code)