### PR TITLE
feat(api): encrypt webhook signing secrets at rest

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,6 +85,9 @@ jobs:
     env:
       DATABASE_URL: postgresql://agent_identity:agent_identity@localhost:5433/agent_identity_test
       NODE_ENV: test
+      # Throwaway key so the webhook integration tests exercise the real
+      # encrypt-at-rest → decrypt-to-sign path, not the plaintext fallback.
+      SECRET_ENCRYPTION_KEY: fedcba9876543210fedcba9876543210fedcba9876543210fedcba9876543210
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
@@ -243,6 +246,7 @@ jobs:
             -e NODE_ENV=production \
             -e PORT=4000 \
             -e SESSION_SECRET="ci-smoke-test-session-secret-not-a-real-secret-0123456789" \
+            -e SECRET_ENCRYPTION_KEY="0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef" \
             -e PUBLIC_API_URL="http://localhost:4000" \
             sidclaw-api:ci
       - name: Wait for /health

--- a/apps/api/.env.example
+++ b/apps/api/.env.example
@@ -29,3 +29,9 @@ STRIPE_WEBHOOK_SECRET=whsec_...
 
 # Platform Admin
 SUPER_ADMIN_KEY=               # generate with: openssl rand -hex 32
+
+# At-rest encryption for webhook signing secrets (REQUIRED in production).
+# Generate with: openssl rand -hex 32
+# After setting it on an existing deployment, backfill legacy rows once:
+#   npx tsx scripts/encrypt-webhook-secrets.ts
+SECRET_ENCRYPTION_KEY=

--- a/apps/api/scripts/encrypt-webhook-secrets.ts
+++ b/apps/api/scripts/encrypt-webhook-secrets.ts
@@ -1,0 +1,37 @@
+/**
+ * One-time backfill: encrypt legacy plaintext webhook signing secrets.
+ *
+ * Usage (from apps/api, with DATABASE_URL and SECRET_ENCRYPTION_KEY set):
+ *   npx tsx scripts/encrypt-webhook-secrets.ts
+ *
+ * Idempotent — already-encrypted rows are skipped. Run once after setting
+ * SECRET_ENCRYPTION_KEY in the deployment environment.
+ */
+import { PrismaClient } from '../src/generated/prisma/index.js';
+import { encryptSecret, isEncrypted } from '../src/lib/secret-crypto.js';
+
+if (!/^[0-9a-fA-F]{64}$/.test(process.env['SECRET_ENCRYPTION_KEY'] ?? '')) {
+  console.error('SECRET_ENCRYPTION_KEY must be set to 64 hex characters (openssl rand -hex 32)');
+  process.exit(1);
+}
+
+const prisma = new PrismaClient();
+
+const endpoints = await prisma.webhookEndpoint.findMany({ select: { id: true, secret: true } });
+let encrypted = 0;
+let skipped = 0;
+
+for (const endpoint of endpoints) {
+  if (isEncrypted(endpoint.secret)) {
+    skipped++;
+    continue;
+  }
+  await prisma.webhookEndpoint.update({
+    where: { id: endpoint.id },
+    data: { secret: encryptSecret(endpoint.secret) },
+  });
+  encrypted++;
+}
+
+console.log(`Done: ${encrypted} encrypted, ${skipped} already encrypted, ${endpoints.length} total.`);
+await prisma.$disconnect();

--- a/apps/api/src/lib/secret-crypto.test.ts
+++ b/apps/api/src/lib/secret-crypto.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { encryptSecret, decryptSecret, isEncrypted } from './secret-crypto.js';
+
+const KEY = 'a'.repeat(64);
+
+describe('secret-crypto', () => {
+  const original = process.env['SECRET_ENCRYPTION_KEY'];
+
+  beforeEach(() => {
+    process.env['SECRET_ENCRYPTION_KEY'] = KEY;
+  });
+
+  afterEach(() => {
+    if (original === undefined) delete process.env['SECRET_ENCRYPTION_KEY'];
+    else process.env['SECRET_ENCRYPTION_KEY'] = original;
+  });
+
+  it('round-trips a secret', () => {
+    const stored = encryptSecret('whsec_super_secret_value');
+    expect(isEncrypted(stored)).toBe(true);
+    expect(stored).not.toContain('whsec_super_secret_value');
+    expect(decryptSecret(stored)).toBe('whsec_super_secret_value');
+  });
+
+  it('produces a different ciphertext per call (fresh IV)', () => {
+    expect(encryptSecret('same')).not.toBe(encryptSecret('same'));
+  });
+
+  it('passes legacy plaintext through decryptSecret unchanged', () => {
+    expect(isEncrypted('legacy_plaintext_secret')).toBe(false);
+    expect(decryptSecret('legacy_plaintext_secret')).toBe('legacy_plaintext_secret');
+  });
+
+  it('stores plaintext when no key is configured', () => {
+    delete process.env['SECRET_ENCRYPTION_KEY'];
+    expect(encryptSecret('plain')).toBe('plain');
+  });
+
+  it('throws on tampered ciphertext', () => {
+    const stored = encryptSecret('victim');
+    // flip a character inside the ciphertext section
+    const tampered = stored.slice(0, -2) + (stored.endsWith('A') ? 'B' : 'A') + stored.slice(-1);
+    expect(() => decryptSecret(tampered)).toThrow();
+  });
+
+  it('throws when encrypted value found but key missing', () => {
+    const stored = encryptSecret('value');
+    delete process.env['SECRET_ENCRYPTION_KEY'];
+    expect(() => decryptSecret(stored)).toThrow(/not configured/);
+  });
+
+  it('rejects malformed keys', () => {
+    process.env['SECRET_ENCRYPTION_KEY'] = 'too-short';
+    expect(() => encryptSecret('x')).toThrow(/64 hex/);
+  });
+});

--- a/apps/api/src/lib/secret-crypto.ts
+++ b/apps/api/src/lib/secret-crypto.ts
@@ -1,0 +1,63 @@
+import { createCipheriv, createDecipheriv, randomBytes } from 'crypto';
+
+/**
+ * At-rest encryption for stored secrets (webhook signing secrets).
+ *
+ * Format: `enc:v1:<iv b64>:<authTag b64>:<ciphertext b64>` (AES-256-GCM).
+ * Values without the prefix are legacy plaintext rows and are passed through
+ * by decryptSecret so existing endpoints keep signing until backfilled
+ * (scripts/encrypt-webhook-secrets.ts).
+ *
+ * Key: SECRET_ENCRYPTION_KEY, 64 hex chars (32 bytes). In production the
+ * server refuses to boot without it (see server.ts); in dev/test, absence
+ * means secrets are stored as before (plaintext) so local setups keep
+ * working without extra configuration.
+ */
+
+const PREFIX = 'enc:v1:';
+
+function loadKey(): Buffer | null {
+  const raw = process.env['SECRET_ENCRYPTION_KEY'];
+  if (!raw) return null;
+  if (!/^[0-9a-fA-F]{64}$/.test(raw)) {
+    throw new Error('SECRET_ENCRYPTION_KEY must be exactly 64 hex characters (32 bytes)');
+  }
+  return Buffer.from(raw, 'hex');
+}
+
+/** Encrypts when a key is configured; returns plaintext unchanged otherwise. */
+export function encryptSecret(plaintext: string): string {
+  const key = loadKey();
+  if (!key) return plaintext;
+  const iv = randomBytes(12);
+  const cipher = createCipheriv('aes-256-gcm', key, iv);
+  const ciphertext = Buffer.concat([cipher.update(plaintext, 'utf8'), cipher.final()]);
+  const tag = cipher.getAuthTag();
+  return `${PREFIX}${iv.toString('base64')}:${tag.toString('base64')}:${ciphertext.toString('base64')}`;
+}
+
+/** True if the stored value is in the encrypted format. */
+export function isEncrypted(stored: string): boolean {
+  return stored.startsWith(PREFIX);
+}
+
+/**
+ * Decrypts an encrypted value; passes legacy plaintext through unchanged.
+ * Throws if the value is encrypted but no key is configured, or if the
+ * ciphertext fails authentication (tampered / wrong key).
+ */
+export function decryptSecret(stored: string): string {
+  if (!isEncrypted(stored)) return stored;
+  const key = loadKey();
+  if (!key) {
+    throw new Error('Stored secret is encrypted but SECRET_ENCRYPTION_KEY is not configured');
+  }
+  const parts = stored.slice(PREFIX.length).split(':');
+  if (parts.length !== 3) {
+    throw new Error('Malformed encrypted secret');
+  }
+  const [ivB64, tagB64, ctB64] = parts as [string, string, string];
+  const decipher = createDecipheriv('aes-256-gcm', key, Buffer.from(ivB64, 'base64'));
+  decipher.setAuthTag(Buffer.from(tagB64, 'base64'));
+  return Buffer.concat([decipher.update(Buffer.from(ctB64, 'base64')), decipher.final()]).toString('utf8');
+}

--- a/apps/api/src/routes/webhooks.ts
+++ b/apps/api/src/routes/webhooks.ts
@@ -2,6 +2,7 @@ import { FastifyInstance } from 'fastify';
 import type { PrismaClient } from '../generated/prisma/index.js';
 import { z } from 'zod';
 import { randomBytes, createHmac } from 'node:crypto';
+import { encryptSecret, decryptSecret } from '../lib/secret-crypto.js';
 import { NotFoundError, ValidationError } from '../errors.js';
 import { VALID_WEBHOOK_EVENT_TYPES } from '../services/webhook-service.js';
 import { assertUrlIsSafe, safeFetch, UrlSafetyError } from '../lib/url-safety.js';
@@ -59,7 +60,7 @@ export async function webhookRoutes(app: FastifyInstance) {
       data: {
         tenant_id: request.tenantId!,
         url: body.url,
-        secret,
+        secret: encryptSecret(secret),
         events: body.events,
         description: body.description ?? null,
       },
@@ -227,7 +228,7 @@ export async function webhookRoutes(app: FastifyInstance) {
     };
 
     const body = JSON.stringify(testPayload);
-    const signature = 'sha256=' + createHmac('sha256', endpoint.secret).update(body).digest('hex');
+    const signature = 'sha256=' + createHmac('sha256', decryptSecret(endpoint.secret)).update(body).digest('hex');
 
     const startTime = Date.now();
     try {

--- a/apps/api/src/server.ts
+++ b/apps/api/src/server.ts
@@ -31,6 +31,13 @@ if (config.environment === 'production') {
     console.error('FATAL: Missing required configuration: PUBLIC_API_URL (or API_PUBLIC_URL)');
     process.exit(1);
   }
+  // Webhook signing secrets are encrypted at rest with this key. Refusing to
+  // boot without it prevents a deploy from silently writing new secrets in
+  // plaintext (dev/test fall back to plaintext by design).
+  if (!/^[0-9a-fA-F]{64}$/.test(process.env.SECRET_ENCRYPTION_KEY ?? '')) {
+    console.error('FATAL: SECRET_ENCRYPTION_KEY must be set to 64 hex characters (openssl rand -hex 32)');
+    process.exit(1);
+  }
 }
 
 const app = Fastify({

--- a/apps/api/src/services/webhook-service.ts
+++ b/apps/api/src/services/webhook-service.ts
@@ -1,5 +1,6 @@
 import type { PrismaClient } from '../generated/prisma/index.js';
 import { createHmac } from 'node:crypto';
+import { decryptSecret } from '../lib/secret-crypto.js';
 import { safeFetch, UrlSafetyError } from '../lib/url-safety.js';
 import { WebhookEventTypeValues, type WebhookEventType } from '@sidclaw/shared';
 
@@ -64,7 +65,7 @@ export class WebhookService {
     if (!delivery || delivery.status === 'delivered') return;
 
     const payload = JSON.stringify(delivery.payload);
-    const signature = 'sha256=' + createHmac('sha256', delivery.endpoint.secret).update(payload).digest('hex');
+    const signature = 'sha256=' + createHmac('sha256', decryptSecret(delivery.endpoint.secret)).update(payload).digest('hex');
 
     try {
       // safeFetch does: (a) SSRF validation via assertUrlIsSafe, (b) pins the


### PR DESCRIPTION
Closes a long-standing known gap: `WebhookEndpoint.secret` was stored in plaintext, so a database leak handed an attacker valid-signature forgery against every tenant's webhook consumer.

**Design**
- AES-256-GCM under `SECRET_ENCRYPTION_KEY` (64 hex chars); stored as `enc:v1:<iv>:<tag>:<ct>`, fresh IV per value
- Encrypt at endpoint creation; decrypt at both signing sites (delivery + `/test`)
- Legacy plaintext rows pass through on decrypt, so existing endpoints keep working until the idempotent backfill (`apps/api/scripts/encrypt-webhook-secrets.ts`) is run
- Production boot gate (same pattern as `SESSION_SECRET`): refuses to start without the key, so a deploy can't silently write new secrets in plaintext; dev/test fall back to plaintext by design
- 7 unit tests (round-trip, fresh-IV, passthrough, tamper-detection, missing-key, malformed-key); `test-api` now runs with a throwaway key so the integration suite exercises the real encrypt→decrypt path

## ⚠️ Merge order — DO NOT merge before step 1
1. On Railway (platform service): set `SECRET_ENCRYPTION_KEY` = output of `openssl rand -hex 32`
2. Merge this PR (deploy picks up the key)
3. Once, from a shell with prod `DATABASE_URL` + the key: `npx tsx scripts/encrypt-webhook-secrets.ts`

Merging before step 1 will fail the production boot gate and 502 the API.

🤖 Generated with [Claude Code](https://claude.com/claude-code)