### PR TITLE
fix(docker): guard per-workspace node_modules dirs against hoisting changes

### DIFF
--- a/apps/demo-devops/Dockerfile
+++ b/apps/demo-devops/Dockerfile
@@ -6,6 +6,10 @@ COPY packages/shared/package.json ./packages/shared/
 COPY packages/sdk/package.json ./packages/sdk/
 COPY apps/demo-devops/package.json ./apps/demo-devops/
 RUN git init && npm ci --include=dev && rm -rf .git
+# npm decides per-lockfile whether a workspace gets a nested node_modules
+# (hoisting). The build stage COPYs these paths, and COPY has no
+# if-exists — guarantee the dirs so a hoisting change can't break the build.
+RUN mkdir -p packages/sdk/node_modules packages/shared/node_modules apps/demo-devops/node_modules
 
 FROM node:24-alpine AS build
 WORKDIR /app

--- a/apps/demo-healthcare/Dockerfile
+++ b/apps/demo-healthcare/Dockerfile
@@ -6,6 +6,10 @@ COPY packages/shared/package.json ./packages/shared/
 COPY packages/sdk/package.json ./packages/sdk/
 COPY apps/demo-healthcare/package.json ./apps/demo-healthcare/
 RUN git init && npm ci --include=dev && rm -rf .git
+# npm decides per-lockfile whether a workspace gets a nested node_modules
+# (hoisting). The build stage COPYs these paths, and COPY has no
+# if-exists — guarantee the dirs so a hoisting change can't break the build.
+RUN mkdir -p packages/sdk/node_modules packages/shared/node_modules apps/demo-healthcare/node_modules
 
 FROM node:24-alpine AS build
 WORKDIR /app

--- a/apps/demo/Dockerfile
+++ b/apps/demo/Dockerfile
@@ -6,6 +6,10 @@ COPY packages/shared/package.json ./packages/shared/
 COPY packages/sdk/package.json ./packages/sdk/
 COPY apps/demo/package.json ./apps/demo/
 RUN git init && npm ci --include=dev && rm -rf .git
+# npm decides per-lockfile whether a workspace gets a nested node_modules
+# (hoisting). The build stage COPYs these paths, and COPY has no
+# if-exists — guarantee the dirs so a hoisting change can't break the build.
+RUN mkdir -p packages/sdk/node_modules packages/shared/node_modules apps/demo/node_modules
 
 FROM node:24-alpine AS build
 WORKDIR /app


### PR DESCRIPTION
The demo Dockerfiles `COPY` nested workspace `node_modules` dirs from the deps stage, but whether npm creates them depends on the lockfile's hoisting outcome — dependency bumps elsewhere can make them vanish, and `COPY` has no if-exists. `docker-images (demo-atlas)` caught exactly this on #79 and #80. `mkdir -p` after `npm ci` makes the paths unconditional.

Fourth instance of the hoisting-assumption failure class; same guard jobs caught all four pre-merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)