### PR TITLE
feat(api): Redis-backed rate limiting behind REDIS_URL

### DIFF
--- a/apps/api/.env.example
+++ b/apps/api/.env.example
@@ -10,6 +10,9 @@ DASHBOARD_URL=http://localhost:3000
 
 # Rate limiting (set to false for development)
 RATE_LIMIT_ENABLED=true
+# Optional: shared rate-limit state for multi-instance deployments.
+# Unset = per-process in-memory limiter (fine for a single instance).
+# REDIS_URL=redis://localhost:6379
 
 # GitHub OAuth (optional — signup via GitHub disabled if not set)
 GITHUB_CLIENT_ID=

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -30,6 +30,7 @@
     "dotenv": "^16.6.1",
     "fastify": "^5",
     "fastify-plugin": "^5.1.0",
+    "ioredis": "^5.11.1",
     "openid-client": "^6.8.4",
     "pg": "^8.22.0",
     "pino": "^10.3.1",

--- a/apps/api/src/middleware/rate-limit.ts
+++ b/apps/api/src/middleware/rate-limit.ts
@@ -1,5 +1,8 @@
 import fp from 'fastify-plugin';
 import { FastifyInstance, FastifyRequest, FastifyReply } from 'fastify';
+// Importing ioredis does not open a connection — a client is only
+// constructed when REDIS_URL is configured (see createRateLimiter).
+import Redis from 'ioredis';
 
 // ─── Interfaces ──────────────────────────────────────────────────────────────
 
@@ -12,6 +15,8 @@ export interface RateLimitResult {
 
 export interface RateLimiter {
   check(key: string, limit: number, windowSeconds: number): Promise<RateLimitResult>;
+  /** Clear all window state. Used by tests. */
+  reset(): void | Promise<void>;
 }
 
 // ─── In-Memory Implementation ────────────────────────────────────────────────
@@ -57,6 +62,72 @@ export class InMemoryRateLimiter implements RateLimiter {
   }
 }
 
+// ─── Redis Implementation ────────────────────────────────────────────────────
+
+interface RedisMultiChain {
+  incr(key: string): RedisMultiChain;
+  expire(key: string, seconds: number, nx: 'NX'): RedisMultiChain;
+  exec(): Promise<unknown>;
+}
+
+export interface RedisLike {
+  multi(): RedisMultiChain;
+  ttl(key: string): Promise<number>;
+}
+
+/**
+ * Redis-backed fixed-window rate limiter for multi-instance deployments.
+ * Enabled by setting REDIS_URL. Uses INCR + EXPIRE NX so all instances share
+ * one window per key.
+ *
+ * Degrades rather than breaks: if Redis is unreachable, falls back to the
+ * per-process in-memory limiter (weaker isolation, but requests keep flowing
+ * and abuse is still bounded per instance) and logs the failure at most once
+ * per minute.
+ */
+export class RedisRateLimiter implements RateLimiter {
+  private readonly fallback = new InMemoryRateLimiter();
+  private lastErrorLogAt = 0;
+
+  // Structural type covering the slice of ioredis the limiter uses; kept
+  // loose so tests can supply an in-process fake without a Redis server.
+  constructor(private readonly redis: RedisLike) {}
+
+  async check(key: string, limit: number, windowSeconds: number): Promise<RateLimitResult> {
+    const now = Math.floor(Date.now() / 1000);
+    const redisKey = `ratelimit:${key}:${Math.floor(now / windowSeconds)}`;
+    try {
+      const results = (await this.redis
+        .multi()
+        .incr(redisKey)
+        // NX: only set the TTL when the key has none — first request in the
+        // window owns the expiry; later requests must not extend it.
+        .expire(redisKey, windowSeconds, 'NX')
+        .exec()) as Array<[Error | null, unknown]> | null;
+      if (!results) throw new Error('redis MULTI aborted');
+      const [incrErr, count] = results[0]!;
+      if (incrErr) throw incrErr;
+      const used = Number(count);
+      return {
+        allowed: used <= limit,
+        limit,
+        remaining: Math.max(0, limit - used),
+        resetAt: (Math.floor(now / windowSeconds) + 1) * windowSeconds,
+      };
+    } catch (error) {
+      if (now - this.lastErrorLogAt >= 60) {
+        this.lastErrorLogAt = now;
+        console.error('Rate limiter: Redis unavailable, using in-memory fallback:', error instanceof Error ? error.message : error);
+      }
+      return this.fallback.check(key, limit, windowSeconds);
+    }
+  }
+
+  reset(): void {
+    this.fallback.reset();
+  }
+}
+
 // ─── Rate Limit Tiers ────────────────────────────────────────────────────────
 
 export interface RateLimitTier {
@@ -80,7 +151,22 @@ export function getEndpointCategory(method: string, url: string): 'evaluate' | '
 
 // ─── Fastify Plugin ──────────────────────────────────────────────────────────
 
-export const rateLimiter = new InMemoryRateLimiter();
+function createRateLimiter(): RateLimiter {
+  const redisUrl = process.env['REDIS_URL'];
+  if (!redisUrl) return new InMemoryRateLimiter();
+  const client = new Redis(redisUrl, {
+    // Never let a slow Redis stall requests: short timeouts, no retry queue.
+    connectTimeout: 2000,
+    commandTimeout: 1000,
+    maxRetriesPerRequest: 1,
+    enableOfflineQueue: false,
+    lazyConnect: false,
+  });
+  console.log('Rate limiter: using Redis backend');
+  return new RedisRateLimiter(client);
+}
+
+export const rateLimiter = createRateLimiter();
 
 async function rateLimitPluginImpl(app: FastifyInstance) {
   app.addHook('onRequest', async (request: FastifyRequest, reply: FastifyReply) => {

--- a/apps/api/src/middleware/redis-rate-limit.test.ts
+++ b/apps/api/src/middleware/redis-rate-limit.test.ts
@@ -1,0 +1,83 @@
+import { describe, it, expect, vi } from 'vitest';
+import { RedisRateLimiter } from './rate-limit.js';
+
+/** Minimal in-process fake of the Redis commands the limiter uses. */
+function fakeRedis(initial: Record<string, number> = {}) {
+  const store = new Map<string, number>(Object.entries(initial));
+  return {
+    store,
+    multi() {
+      const ops: Array<() => [null, unknown]> = [];
+      const chain = {
+        incr: (key: string) => {
+          ops.push(() => {
+            const next = (store.get(key) ?? 0) + 1;
+            store.set(key, next);
+            return [null, next];
+          });
+          return chain;
+        },
+        expire: (_key: string, _s: number, _nx: 'NX') => {
+          ops.push(() => [null, 1]);
+          return chain;
+        },
+        exec: async () => ops.map((op) => op()),
+      };
+      return chain;
+    },
+    ttl: async () => 60,
+  };
+}
+
+describe('RedisRateLimiter', () => {
+  it('counts across calls and enforces the limit', async () => {
+    const limiter = new RedisRateLimiter(fakeRedis());
+    const first = await limiter.check('tenant:read', 2, 60);
+    expect(first).toMatchObject({ allowed: true, remaining: 1 });
+    await limiter.check('tenant:read', 2, 60);
+    const third = await limiter.check('tenant:read', 2, 60);
+    expect(third.allowed).toBe(false);
+    expect(third.remaining).toBe(0);
+  });
+
+  it('keys are shared state — a second limiter over the same store sees the count', async () => {
+    const redis = fakeRedis();
+    const a = new RedisRateLimiter(redis);
+    const b = new RedisRateLimiter(redis);
+    await a.check('k', 2, 60);
+    await b.check('k', 2, 60);
+    const result = await b.check('k', 2, 60);
+    expect(result.allowed).toBe(false);
+  });
+
+  it('falls back to in-memory when Redis errors, and requests keep flowing', async () => {
+    const broken = {
+      multi() {
+        return {
+          incr: () => broken.multi(),
+          expire: () => broken.multi(),
+          exec: async () => {
+            throw new Error('ECONNREFUSED');
+          },
+          // satisfy the structural chain type
+        } as never;
+      },
+      ttl: async () => -1,
+    };
+    const spy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const limiter = new RedisRateLimiter(broken as never);
+    const first = await limiter.check('k', 1, 60);
+    expect(first.allowed).toBe(true);
+    const second = await limiter.check('k', 1, 60);
+    expect(second.allowed).toBe(false); // in-memory fallback still enforces
+    expect(spy).toHaveBeenCalledTimes(1); // error logged once, not per request
+    spy.mockRestore();
+  });
+
+  it('reset clears the fallback state', async () => {
+    const limiter = new RedisRateLimiter(fakeRedis());
+    limiter.reset();
+    const result = await limiter.check('k', 5, 60);
+    expect(result.allowed).toBe(true);
+  });
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -35,6 +35,7 @@
         "dotenv": "^16.6.1",
         "fastify": "^5",
         "fastify-plugin": "^5.1.0",
+        "ioredis": "^5.11.1",
         "openid-client": "^6.8.4",
         "pg": "^8.22.0",
         "pino": "^10.3.1",
@@ -2457,6 +2458,12 @@
       "funding": {
         "url": "https://opencollective.com/libvips"
       }
+    },
+    "node_modules/@ioredis/commands": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@ioredis/commands/-/commands-1.10.0.tgz",
+      "integrity": "sha512-UmeW7z4LfctwoQ5wkhVzgq8tXkreED2xZGpX+Bg+zA+WJFZCT6c062AfCK/Dfk81xZnnwdhJCUMkitihRaoC2Q==",
+      "license": "MIT"
     },
     "node_modules/@jridgewell/gen-mapping": {
       "version": "0.3.13",
@@ -7275,6 +7282,15 @@
         "node": ">=6"
       }
     },
+    "node_modules/cluster-key-slot": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/cluster-key-slot/-/cluster-key-slot-1.1.1.tgz",
+      "integrity": "sha512-rwHwUfXL40Chm1r08yrhU3qpUvdVlgkKNeyeGPOxnW8/SyVDvgRaed/Uz54AqWNaTCAThlj6QAs3TZcKI0xDEw==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/collapse-white-space": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/collapse-white-space/-/collapse-white-space-2.1.0.tgz",
@@ -7884,7 +7900,6 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/denque/-/denque-2.1.0.tgz",
       "integrity": "sha512-HVQE3AAb/pxF8fQAoiqpvg9i3evqug3hoiwakOyZAwJm+6vZehbkYXZ0l4JxS+I3QxM97v5aaRNhj8v5oBhekw==",
-      "devOptional": true,
       "license": "Apache-2.0",
       "engines": {
         "node": ">=0.10"
@@ -10432,6 +10447,28 @@
       "license": "ISC",
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/ioredis": {
+      "version": "5.11.1",
+      "resolved": "https://registry.npmjs.org/ioredis/-/ioredis-5.11.1.tgz",
+      "integrity": "sha512-ehuGcf94bQXhfagULNXrJdfnWO38v070jxSx/qE87Kjzmu2fU7ro5EFAb+OPituLqgfyuQaym5DlrNydW2sJ9A==",
+      "license": "MIT",
+      "dependencies": {
+        "@ioredis/commands": "1.10.0",
+        "cluster-key-slot": "1.1.1",
+        "debug": "4.4.3",
+        "denque": "2.1.0",
+        "redis-errors": "1.2.0",
+        "redis-parser": "3.0.0",
+        "standard-as-callback": "2.1.0"
+      },
+      "engines": {
+        "node": ">=12.22.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/ioredis"
       }
     },
     "node_modules/ip-address": {
@@ -14744,6 +14781,27 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/redis-errors": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/redis-errors/-/redis-errors-1.2.0.tgz",
+      "integrity": "sha512-1qny3OExCf0UvUV/5wpYKf2YwPcOqXzkwKKSmKHiE6ZMQs5heeE/c8eXK+PNllPvmjgAbfnsbpkGZWy8cBpn9w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/redis-parser": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/redis-parser/-/redis-parser-3.0.0.tgz",
+      "integrity": "sha512-DJnGAeenTdpMEH6uAJRK/uiyEIH9WVsUmoLwzudwGJUwZPp80PDBWPHXSAGNPwNvIXAbe7MSUB1zQFugFml66A==",
+      "license": "MIT",
+      "dependencies": {
+        "redis-errors": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/reflect.getprototypeof": {
       "version": "1.0.10",
       "resolved": "https://registry.npmjs.org/reflect.getprototypeof/-/reflect.getprototypeof-1.0.10.tgz",
@@ -15674,6 +15732,12 @@
       "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
       "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/standard-as-callback": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/standard-as-callback/-/standard-as-callback-2.1.0.tgz",
+      "integrity": "sha512-qoRRSyROncaz1z0mvYqIE4lCd9p2R90i6GxW3uZv5ucSu8tU7B5HXUP1gG8pVZsYNVaXjk8ClXHPttLyxAL48A==",
       "license": "MIT"
     },
     "node_modules/standardwebhooks": {


### PR DESCRIPTION
Closes the 'in-memory rate limiter (needs Redis for horizontal scaling)' known gap.

- `RedisRateLimiter` implements the existing `RateLimiter` interface with fixed windows shared across instances (`INCR` + `EXPIRE NX` — first request in the window owns the expiry)
- Env-driven selection: `REDIS_URL` set → Redis; unset → the in-memory limiter exactly as before (dev/test unchanged, no new infra required)
- **Degrades, never breaks**: on Redis errors the limiter falls back to in-memory (requests keep flowing; abuse still bounded per instance), error logs throttled to once/minute; ioredis configured with 1–2s timeouts, no offline queue, `maxRetriesPerRequest: 1` so a slow Redis cannot stall the request path
- 4 unit tests incl. cross-client shared-state enforcement and the error-fallback path

Deploy note (optional, whenever scaling happens): add a Redis service on Railway and set `REDIS_URL` on the platform service. Nothing to do today — single-instance behavior is identical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)