### PR TITLE
fix: dev-login redirect + re-enable browser E2E suite (nightly)

### DIFF
--- a/.github/workflows/browser-tests.yml
+++ b/.github/workflows/browser-tests.yml
@@ -1,0 +1,57 @@
+# Full-browser E2E suite (Playwright, ~30 min sequential) — nightly rather
+# than per-PR: the suite drives real dev servers against a seeded database
+# and shares state across specs (workers: 1), so it is too heavy for every
+# push but too valuable to stay disabled (it was dark for 4 months and hid a
+# broken dev-login redirect the unit/integration layers cannot see).
+name: Browser Tests
+
+on:
+  schedule:
+    - cron: '17 3 * * *' # nightly, 03:17 UTC
+  workflow_dispatch:
+
+jobs:
+  playwright:
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    services:
+      postgres:
+        image: postgres:16-alpine
+        env:
+          POSTGRES_DB: agent_identity
+          POSTGRES_USER: agent_identity
+          POSTGRES_PASSWORD: agent_identity
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U agent_identity"
+          --health-interval 5s
+          --health-timeout 3s
+          --health-retries 5
+    env:
+      DATABASE_URL: postgresql://agent_identity:agent_identity@localhost:5432/agent_identity
+      RATE_LIMIT_ENABLED: 'false'
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: '24'
+          cache: 'npm'
+      - run: npm ci
+      - name: Generate Prisma client
+        working-directory: apps/api
+        run: npx prisma generate
+      - name: Build workspace dependencies
+        run: npx turbo build --filter=@sidclaw/shared --filter=@sidclaw/sdk
+      - name: Install Playwright browsers
+        run: npx playwright install --with-deps chromium
+      - name: Run browser tests
+        # playwright.config.ts starts the API and dashboard dev servers itself
+        run: npx playwright test
+      - name: Upload traces on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-traces
+          path: test-results/
+          retention-days: 7

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -118,8 +118,9 @@ jobs:
         run: npx prisma generate
       - run: npx turbo build
 
-  # test-browser: disabled — browser test suite needs update for current auth flow
-  # Re-enable when tests/browser/ is fixed
+  # Browser E2E suite: nightly in browser-tests.yml (~30 min sequential, too
+  # heavy per-PR). Re-enabled 2026-07-29 after fixing the dev-login redirect
+  # that had broken its auth setup.
 
   verify-sdk-package:
     runs-on: ubuntu-latest

--- a/apps/api/src/routes/auth.ts
+++ b/apps/api/src/routes/auth.ts
@@ -575,7 +575,7 @@ export async function authRoutes(app: FastifyInstance) {
       const csrfToken = randomUUID();
 
       setSessionCookies(reply, sessionId, csrfToken);
-      return reply.redirect(redirectUri);
+      return reply.redirect(`${dashboardUrl}${redirectUri}`);
     });
   }
 


### PR DESCRIPTION
**The 99-spec Playwright suite was disabled for 4 months over a single bug.** `dev-login` issued a relative redirect, which `reply.redirect` resolves against the API's own origin — browsers landed on `localhost:4000/dashboard` (404), so the suite's auth setup died before any spec ran. The same bug broke the dashboard's 'Sign in with SSO' dev flow.

**Fix**: prefix `dashboardUrl` (safe — `sanitizeRedirectUri` guarantees a relative path, so no open-redirect surface). Auth integration tests: 18/18.

**Full local suite with the fix**: 60 passed, 1 flaky (green on retry), 5 skipped, 5 demo specs that need the demo apps running, **0 failures** — 31 minutes sequential.

**CI**: new `browser-tests.yml` — nightly at 03:17 UTC + `workflow_dispatch`, Postgres service, Playwright-managed dev servers, traces uploaded on failure. Nightly rather than per-PR because ~30 sequential minutes against live dev servers is too heavy for every push and too valuable to stay dark — it was exactly this suite that would have caught the dev-login break when it happened.

🤖 Generated with [Claude Code](https://claude.com/claude-code)