### PR TITLE
fix(browser-tests): start the landing app for the landing-page specs

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -28,6 +28,15 @@ export default defineConfig({
       reuseExistingServer: true,
       timeout: 30000,
     },
+    {
+      // The landing-page specs (01-*) target the landing app directly.
+      // Locally an absent server made them skip; in CI they hard-failed
+      // with ERR_CONNECTION_REFUSED on the suite's first scheduled run.
+      command: 'cd apps/landing && npm run dev',
+      port: 3002,
+      reuseExistingServer: true,
+      timeout: 60000,
+    },
   ],
   projects: [
     {


### PR DESCRIPTION
First scheduled validation run of `browser-tests.yml` failed on the 01-landing-page specs: they target `:3002` (the landing app), which the Playwright `webServer` list never started. Locally the absent server made them skip quietly; in CI they hard-fail with `ERR_CONNECTION_REFUSED`. Adds the landing dev server to the managed set.

Will re-dispatch the workflow after merge to confirm the suite goes green in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)