### PR TITLE
fix(seed): dev key gets full non-admin scopes, and upsert updates them

### DIFF
--- a/apps/api/prisma/seed.ts
+++ b/apps/api/prisma/seed.ts
@@ -4,7 +4,6 @@ import crypto from 'node:crypto';
 import fs from 'node:fs';
 import path from 'node:path';
 import { hash } from 'bcrypt';
-import { DEFAULT_SIGNUP_KEY_SCOPES } from '@sidclaw/shared';
 
 const connectionString = process.env['DATABASE_URL'] ?? 'postgresql://agent_identity:agent_identity@localhost:5432/agent_identity';
 const adapter = new PrismaPg({ connectionString });
@@ -58,11 +57,32 @@ async function main() {
   const rawKey = `ai_dev_${crypto.randomBytes(16).toString('hex')}`;
   const keyHash = crypto.createHash('sha256').update(rawKey).digest('hex');
 
+  // The dev key drives the local demo script and the browser E2E harness,
+  // which create agents and policies — it needs every scope except admin.
+  // (It previously seeded with the runtime-only signup scopes, and — worse —
+  // the upsert's update branch didn't touch scopes at all, so long-lived dev
+  // databases kept whatever scopes the row had when first created. That
+  // divergence made the E2E suite green locally and 403 on fresh CI
+  // databases.)
+  const DEV_KEY_SCOPES = [
+    'evaluate',
+    'agents:read',
+    'agents:write',
+    'agents:lifecycle',
+    'policies:read',
+    'policies:write',
+    'traces:read',
+    'traces:write',
+    'approvals:read',
+    'approvals:write',
+  ];
+
   const apiKey = await prisma.apiKey.upsert({
     where: { id: 'apikey-dev' },
     update: {
       key_prefix: rawKey.substring(0, 12),
       key_hash: keyHash,
+      scopes: DEV_KEY_SCOPES,
     },
     create: {
       id: 'apikey-dev',
@@ -70,7 +90,7 @@ async function main() {
       name: 'Development Key',
       key_prefix: rawKey.substring(0, 12),
       key_hash: keyHash,
-      scopes: DEFAULT_SIGNUP_KEY_SCOPES,
+      scopes: DEV_KEY_SCOPES,
     },
   });
 


### PR DESCRIPTION
Root cause of the browser-suite CI failures (dispatches 2 and 3, identical 403 signatures): the seeded dev key had runtime-only signup scopes on fresh databases, while long-lived local databases kept legacy wide scopes because **the seed's upsert update branch never wrote `scopes`** — a silent local/CI divergence.

The dev key now gets every scope except `admin` (it drives `scripts/demo.ts` and the E2E harness, which create agents/policies and decide approvals), and the update branch keeps scopes in sync on reseed.

Will re-dispatch `browser-tests.yml` after merge — fourth validation attempt, third distinct root cause (missing landing server → missing env parity → seed scope drift).

🤖 Generated with [Claude Code](https://claude.com/claude-code)