### PR TITLE
fix(browser-tests): current enum vocabulary + scoped outcome-badge assertion

### DIFF
--- a/tests/browser/specs/07-agents-lifecycle.spec.ts
+++ b/tests/browser/specs/07-agents-lifecycle.spec.ts
@@ -16,8 +16,10 @@ test.describe('Agent Lifecycle Management', () => {
       owner_role: 'qa_engineer',
       team: 'QA',
       authority_model: 'hybrid',
-      identity_mode: 'shared',
-      delegation_model: 'supervised',
+      identity_mode: 'hybrid_identity',
+      delegation_model: 'mixed',
+      environment: 'dev',
+      autonomy_tier: 'medium',
     });
     testAgentId = agent.data.id;
   });

--- a/tests/browser/specs/12-approvals-detail-approve.spec.ts
+++ b/tests/browser/specs/12-approvals-detail-approve.spec.ts
@@ -18,8 +18,10 @@ test.describe('Approval Detail — Approve Flow', () => {
       owner_role: 'engineer',
       team: 'e2e-testing',
       authority_model: 'hybrid',
-      identity_mode: 'service_account',
-      delegation_model: 'none',
+      identity_mode: 'service_identity',
+      delegation_model: 'self',
+      environment: 'dev',
+      autonomy_tier: 'medium',
     });
     approvalAgentId = agent.data.id;
 

--- a/tests/browser/specs/13-approvals-detail-deny.spec.ts
+++ b/tests/browser/specs/13-approvals-detail-deny.spec.ts
@@ -18,8 +18,10 @@ test.describe('Approval Detail — Deny Flow', () => {
       owner_role: 'engineer',
       team: 'e2e-testing',
       authority_model: 'hybrid',
-      identity_mode: 'service_account',
-      delegation_model: 'none',
+      identity_mode: 'service_identity',
+      delegation_model: 'self',
+      environment: 'dev',
+      autonomy_tier: 'medium',
     });
     denyAgentId = agent.data.id;
 

--- a/tests/browser/specs/24-full-governance-flow.spec.ts
+++ b/tests/browser/specs/24-full-governance-flow.spec.ts
@@ -18,6 +18,8 @@ test.describe('Full Governance Flow', () => {
       authority_model: 'hybrid',
       identity_mode: 'service_identity',
       delegation_model: 'self',
+      environment: 'dev',
+      autonomy_tier: 'medium',
     });
     const agentId = agent.data?.id ?? agent.id;
     expect(agentId).toBeTruthy();
@@ -78,7 +80,11 @@ test.describe('Full Governance Flow', () => {
     const eventCount = await events.count();
     expect(eventCount).toBeGreaterThanOrEqual(3);
 
-    // 9. Verify outcome badge shows completed/approved
-    await expect(page.locator(selectors.traces.outcomeBadge)).toContainText(/completed|approved/i);
+    // 9. Verify outcome badge shows completed/approved. Every row in the trace
+    // list carries an outcome-badge, so scope to the selected (first) item —
+    // the unscoped locator trips strict mode once the audit page has history.
+    await expect(
+      page.locator(selectors.traces.listItem).first().locator(selectors.traces.outcomeBadge),
+    ).toContainText(/completed|approved/i);
   });
 });

--- a/tests/browser/specs/25-csrf-protection.spec.ts
+++ b/tests/browser/specs/25-csrf-protection.spec.ts
@@ -22,6 +22,8 @@ test.describe('CSRF Protection', () => {
           authority_model: 'self',
           identity_mode: 'service_identity',
           delegation_model: 'self',
+      environment: 'dev',
+      autonomy_tier: 'medium',
           created_by: 'test',
         }),
       });


### PR DESCRIPTION
Root causes 4 and 5 from the browser-suite CI validation runs:

- **Stale enum vocabulary** in 5 spec files (`identity_mode: 'shared'/'service_account'`, `delegation_model: 'supervised'/'none'`, missing `environment`/`autonomy_tier`). Zod 4 reports missing and invalid enum fields identically, which made the 400s look like a four-field mystery. Honest note: these `beforeAll` crashes were failing **locally too** — they hid inside Playwright's skipped/did-not-run counts, so the earlier '60 passed / 0 failed' overstated local health. CI's stricter accounting exposed them.
- **Unscoped strict-mode locator** in spec 24: the outcome-badge assertion matched every row of the audit list (101 elements on a database with history). Scoped to the selected trace row.

Verified locally: specs 07/12/13/24/25 all pass. Will dispatch validation run #5 after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)