### PR TITLE
fix(browser-tests): production Next builds in CI, dev servers locally

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -15,6 +15,11 @@ export default defineConfig({
     trace: 'on-first-retry',
     viewport: { width: 1440, height: 900 },
   },
+  // In CI the Next.js apps run PRODUCTION builds: dev servers compile each
+  // page on first hit, and on a 2-core runner those compiles blow the 30s
+  // selector timeouts (validation run 30460483491: 35 timeout failures that
+  // never reproduce locally). The API keeps its dev server everywhere — tsx
+  // has no per-page compile step.
   webServer: [
     {
       command: 'cd apps/api && npm run dev',
@@ -23,19 +28,21 @@ export default defineConfig({
       timeout: 30000,
     },
     {
-      command: 'cd apps/dashboard && npm run dev',
+      command: process.env.CI
+        ? 'cd apps/dashboard && npm run build && npm run start'
+        : 'cd apps/dashboard && npm run dev',
       port: 3000,
       reuseExistingServer: true,
-      timeout: 30000,
+      timeout: process.env.CI ? 420000 : 30000,
     },
     {
       // The landing-page specs (01-*) target the landing app directly.
-      // Locally an absent server made them skip; in CI they hard-failed
-      // with ERR_CONNECTION_REFUSED on the suite's first scheduled run.
-      command: 'cd apps/landing && npm run dev',
+      command: process.env.CI
+        ? 'cd apps/landing && npm run build && npm run start'
+        : 'cd apps/landing && npm run dev',
       port: 3002,
       reuseExistingServer: true,
-      timeout: 60000,
+      timeout: process.env.CI ? 420000 : 60000,
     },
   ],
   projects: [


### PR DESCRIPTION
Validation #5 (run 30460483491): **75 passed / 35 failed**, and every failure is a first-visit timeout (landing ×16, signup ×16, …) that never reproduces locally. Classic dev-server-in-CI failure: Next dev compiles pages on first hit and a 2-core runner takes >30s per cold page.

CI now runs `next build && next start` for dashboard and landing (compile paid once inside a 7-min webServer timeout); local runs keep dev servers unchanged. The API stays on its dev server everywhere — tsx has no per-page compile.

Sixth and, evidence suggests, final root cause: 1 missing server → 2 env parity → 3 seed scope drift → 4 stale enum vocab → 5 unscoped locator → 6 dev-server cold compiles. Will dispatch validation #6 after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)