### PR TITLE
fix(browser-tests): scope NODE_ENV per server in CI

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -28,8 +28,13 @@ export default defineConfig({
       timeout: 30000,
     },
     {
+      // NODE_ENV=production explicitly: the CI job exports
+      // NODE_ENV=development for the API's dev auth bypass, and `next build`
+      // under development NODE_ENV prerenders with the dev React runtime and
+      // dies on /404 with the misleading '<Html> imported outside _document'
+      // error (validation run 30464116024).
       command: process.env.CI
-        ? 'cd apps/dashboard && npm run build && npm run start'
+        ? 'cd apps/dashboard && NODE_ENV=production npm run build && NODE_ENV=production npm run start'
         : 'cd apps/dashboard && npm run dev',
       port: 3000,
       reuseExistingServer: true,
@@ -38,7 +43,7 @@ export default defineConfig({
     {
       // The landing-page specs (01-*) target the landing app directly.
       command: process.env.CI
-        ? 'cd apps/landing && npm run build && npm run start'
+        ? 'cd apps/landing && NODE_ENV=production npm run build && NODE_ENV=production npm run start'
         : 'cd apps/landing && npm run dev',
       port: 3002,
       reuseExistingServer: true,


### PR DESCRIPTION
Root cause #7, a collision between two earlier fixes: the job-wide `NODE_ENV=development` (#87, needed for the API's dev auth bypass) poisons `next build` (#90's production servers) — prerender runs with the dev React runtime and fails on `/404` with the misleading `<Html> should not be imported outside pages/_document` error (run 30464116024).

Fix: the two Next apps build and serve under an explicit `NODE_ENV=production` inside their webServer commands; the API keeps inheriting `development`. Will chain validation #7 after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)