### PR TITLE
fix(browser-tests): V2 landing assertions, real auth selectors, demo specs split out

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -59,6 +59,15 @@ export default defineConfig({
       name: 'e2e',
       dependencies: ['setup'],
       testMatch: 'specs/**/*.spec.ts',
+      // The demo specs target the vertical demo apps (ports 3003-3005),
+      // which this config does not manage. Run them explicitly with the
+      // demo apps up: npx playwright test --project=demos
+      testIgnore: 'specs/demo/**',
+    },
+    {
+      name: 'demos',
+      dependencies: ['setup'],
+      testMatch: 'specs/demo/**/*.spec.ts',
     },
   ],
 });

--- a/tests/browser/global-setup.ts
+++ b/tests/browser/global-setup.ts
@@ -29,9 +29,9 @@ setup('create admin session', async ({ browser }) => {
   } else {
     // Fall back to email signup
     await page.goto('http://localhost:3000/signup');
-    await page.fill('input[name="name"]', 'E2E Admin');
-    await page.fill('input[name="email"]', 'e2e-admin@test.com');
-    await page.fill('input[name="password"]', 'E2ETest2026!');
+    await page.fill('#name', 'E2E Admin');
+    await page.fill('#email', 'e2e-admin@test.com');
+    await page.fill('#password', 'E2ETest2026!');
     await page.click('button[type="submit"]');
     await page.waitForURL('**/dashboard**', { timeout: 15000 });
   }

--- a/tests/browser/helpers/auth.ts
+++ b/tests/browser/helpers/auth.ts
@@ -2,9 +2,9 @@ import { Page } from '@playwright/test';
 
 export async function loginAsNewUser(page: Page, name: string, email: string, password: string) {
   await page.goto('/signup');
-  await page.fill('input[name="name"]', name);
-  await page.fill('input[name="email"]', email);
-  await page.fill('input[name="password"]', password);
+  await page.fill('#name', name);
+  await page.fill('#email', email);
+  await page.fill('#password', password);
   await page.click('button[type="submit"]');
   await page.waitForURL('**/dashboard**', { timeout: 15000 });
 }

--- a/tests/browser/helpers/selectors.ts
+++ b/tests/browser/helpers/selectors.ts
@@ -15,9 +15,9 @@ export const selectors = {
 
   // Auth
   auth: {
-    nameInput: 'input[name="name"]',
-    emailInput: 'input[name="email"]',
-    passwordInput: 'input[name="password"]',
+    nameInput: '#name',
+    emailInput: '#email',
+    passwordInput: '#password',
     submitButton: 'button[type="submit"]',
     githubButton: '[data-testid="github-oauth"]',
     googleButton: '[data-testid="google-oauth"]',
@@ -29,7 +29,7 @@ export const selectors = {
     createButton: '[data-testid="create-agent"]',
     table: '[data-testid="agent-table"]',
     row: '[data-testid="agent-row"]',
-    nameInput: 'input[name="name"]',
+    nameInput: '#name',
     descriptionInput: 'textarea[name="description"]',
     ownerNameInput: 'input[name="owner_name"]',
     ownerRoleInput: 'input[name="owner_role"]',

--- a/tests/browser/specs/01-landing-page.spec.ts
+++ b/tests/browser/specs/01-landing-page.spec.ts
@@ -5,45 +5,43 @@ import { expectNoHorizontalOverflow } from '../helpers/assertions';
 const LANDING_URL = 'http://localhost:3002';
 
 test.describe('Landing Page', () => {
-  test('loads with hero section containing approval/accountability/agentic', async ({ page }) => {
+  test('loads with V2 hero: "the missing control plane for agentic AI"', async ({ page }) => {
     await page.goto(LANDING_URL);
 
     const h1 = page.locator('h1');
     await expect(h1).toBeVisible();
 
     const text = await h1.textContent();
-    expect(text?.toLowerCase()).toContain('approval');
-    expect(text?.toLowerCase()).toContain('accountability');
+    expect(text?.toLowerCase()).toContain('control plane');
     expect(text?.toLowerCase()).toContain('agentic');
   });
 
-  test('"Get Started Free" button links to signup', async ({ page }) => {
+  test('"Start Free" CTA links to signup', async ({ page }) => {
     await page.goto(LANDING_URL);
 
-    const cta = page.locator('a', { hasText: 'Get Started Free' });
+    const cta = page.locator('a', { hasText: 'Start Free' }).first();
     await expect(cta).toBeVisible();
 
     const href = await cta.getAttribute('href');
     expect(href).toContain('signup');
   });
 
-  test('"View on GitHub" links to github.com/sidclawhq', async ({ page }) => {
+  test('links to github.com/sidclawhq', async ({ page }) => {
     await page.goto(LANDING_URL);
 
-    const ghLink = page.locator('a', { hasText: 'View on GitHub' });
+    // Multiple GitHub links exist (nav, developer section, footer) — assert
+    // at least one resolves to the org.
+    const ghLink = page.locator('a[href*="github.com/sidclawhq"]').first();
     await expect(ghLink).toBeVisible();
-
-    const href = await ghLink.getAttribute('href');
-    expect(href).toContain('github.com/sidclawhq');
   });
 
-  test('pricing section shows "5 agents" text', async ({ page }) => {
+  test('compliance bar names FINRA and the EU AI Act', async ({ page }) => {
+    // The V2 page has no pricing section; the compliance trust bar is its
+    // regulated-market signal.
     await page.goto(LANDING_URL);
 
-    const pricing = page.locator('#pricing');
-    await expect(pricing).toBeVisible();
-
-    await expect(pricing.locator('text=5 agents')).toBeVisible();
+    await expect(page.locator('text=FINRA').first()).toBeVisible();
+    await expect(page.locator('text=EU AI Act').first()).toBeVisible();
   });
 
   test('has dark theme (#0A0A0B background)', async ({ page }) => {
@@ -67,10 +65,12 @@ test.describe('Landing Page', () => {
     await expectNoHorizontalOverflow(page);
   });
 
-  test('stats cite NeuralTrust source', async ({ page }) => {
+  test('hero pitches identity, policy, approval, and audit', async ({ page }) => {
+    // The V2 page dropped the NeuralTrust stat; the four-primitives pitch is
+    // the stable content anchor.
     await page.goto(LANDING_URL);
 
-    const citation = page.locator('text=NeuralTrust');
-    await expect(citation).toBeVisible();
+    const heroCopy = page.locator('text=tamper-evident audit').first();
+    await expect(heroCopy).toBeVisible();
   });
 });


### PR DESCRIPTION
Root causes 8–10, all spec-drift now that the CI infrastructure works:

- **Landing specs asserted the V1 page** (approval/accountability hero, '5 agents' pricing, NeuralTrust stat). The live page is V2 — control-plane hero, no pricing section, compliance trust bar. Assertions rewritten against what actually renders.
- **Auth specs/helpers used `input[name=…]`** — the login/signup inputs have ids only. Converted to `#id` across specs, helpers, and global-setup.
- **demo-healthcare specs** target :3005, never part of the managed server set — split into an explicit `demos` project (`--project=demos` with the demo apps up); the default run ignores them.

**Full local CI-mode suite: 59 passed / 0 failed / 1 known-flaky (passes on retry) / 5 skipped.** Will chain validation #8 after merge — expected green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)